### PR TITLE
Dev/rspec config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 ### Rails ###
 *.rbc
 capybara-*.html
-.rspec
 /log
 /tmp
 /db/*.sqlite3

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require rails_helper

--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --require rails_helper
+--format doc

--- a/spec/models/admin_user_spec.rb
+++ b/spec/models/admin_user_spec.rb
@@ -17,8 +17,6 @@
 #  updated_at             :datetime         not null
 #
 
-require 'rails_helper'
-
 describe AdminUser do
   it { expect(subject).to respond_to(:email) }
   it { expect(subject).to respond_to(:encrypted_password) }

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -9,8 +9,6 @@
 #  updated_at :datetime         not null
 #
 
-require 'rails_helper'
-
 describe Group, type: :model do
   it { expect(subject).to respond_to :group_name }
   it 'is valid with group name' do

--- a/spec/models/monthly_report_comment_spec.rb
+++ b/spec/models/monthly_report_comment_spec.rb
@@ -10,8 +10,6 @@
 #  updated_at        :datetime         not null
 #
 
-require 'rails_helper'
-
 describe MonthlyReportComment, type: :model do
   it { expect(subject).to respond_to(:id) }
   it { expect(subject).to respond_to(:user_id) }

--- a/spec/models/monthly_report_spec.rb
+++ b/spec/models/monthly_report_spec.rb
@@ -16,8 +16,6 @@
 #  updated_at           :datetime         not null
 #
 
-require 'rails_helper'
-
 RSpec.describe MonthlyReport, type: :model do
   it { expect(subject).to respond_to(:user_id) }
   it { expect(subject).to respond_to(:project_summary) }

--- a/spec/models/monthly_report_tag_spec.rb
+++ b/spec/models/monthly_report_tag_spec.rb
@@ -9,8 +9,6 @@
 #  updated_at        :datetime         not null
 #
 
-require 'rails_helper'
-
 describe MonthlyReportTag, type: :model do
   it { expect(subject).to respond_to(:id) }
   it { expect(subject).to respond_to(:monthly_report_id) }

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -8,8 +8,6 @@
 #  updated_at :datetime         not null
 #
 
-require 'rails_helper'
-
 describe Role, type: :model do
   it { expect(subject).to respond_to(:name) }
 

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -8,8 +8,6 @@
 #  updated_at :datetime         not null
 #
 
-require 'rails_helper'
-
 describe Tag, type: :model do
   it { expect(subject).to respond_to(:name) }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -14,8 +14,6 @@
 #  updated_at    :datetime         not null
 #
 
-require 'rails_helper'
-
 describe User, type: :model do
   describe 'Validations' do
     subject { build(:user) }

--- a/spec/requests/sample_spec.rb
+++ b/spec/requests/sample_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 describe SampleController, type: :request do
   describe 'GET /sample' do
     before { get sample_index_path }

--- a/spec/test_spec.rb
+++ b/spec/test_spec.rb
@@ -1,3 +1,0 @@
-describe 'Test' do
-  it { expect(1).to eq 1 }
-end

--- a/spec/test_spec.rb
+++ b/spec/test_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 describe 'Test' do
   it { expect(1).to eq 1 }
 end

--- a/spec/validators/email_validator_spec.rb
+++ b/spec/validators/email_validator_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 describe EmailValidator, type: :validator do
   let(:model_class) do
     Struct.new(:email_address) do


### PR DESCRIPTION
`.rspec`ファイルに書いておけば、毎回

```
require 'rails_helper'
```

書かなくて済む。
