### PR TITLE
Dev/change md to GitHub markdown

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ gem 'activeadmin', github: 'activeadmin'
 gem 'slim'
 gem 'slim-rails'
 gem 'kaminari'
-gem 'rdiscount'
+gem 'github-markdown'
 
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,6 +132,7 @@ GEM
       actionpack (>= 3.2.13)
     formtastic_i18n (0.4.1)
     git-version-bump (0.15.1)
+    github-markdown (0.6.9)
     global (0.1.2)
       activesupport (>= 2.0)
     globalid (0.3.6)
@@ -353,6 +354,7 @@ DEPENDENCIES
   enum_help
   factory_girl_rails
   faker
+  github-markdown
   global
   identity_cache
   jbuilder (~> 2.0)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,5 @@
 module ApplicationHelper
   def markdown(text)
-    RDiscount.new(text, :autolink, :filter_html, :generate_toc)
+    GitHub::Markdown.render_gfm(h(text))
   end
 end

--- a/app/views/layouts/_markdown_view.html.slim
+++ b/app/views/layouts/_markdown_view.html.slim
@@ -1,2 +1,2 @@
 .markdown-body
-  = markdown(content).to_html.html_safe
+  = markdown(content).html_safe


### PR DESCRIPTION
markdownのレンダリング（サーバー側）をRDiscountからgithub-markdownに変更
- GitHub Flavored Markdownの指定が可能なため
- HTMLタグのエスケープにはhメソッドを使用
