### PR TITLE
Customize admin tag #174

### DIFF
--- a/app/admin/tag.rb
+++ b/app/admin/tag.rb
@@ -1,4 +1,14 @@
 ActiveAdmin.register Tag do
   csv_importable
   permit_params { Tag.column_names }
+  actions :all, except: [:destroy]
+
+  form do |f|
+    f.semantic_errors
+    f.inputs do
+      f.input :name
+      f.input :status, as: :select, collection: Tag.statuses.keys
+    end
+    f.actions
+  end
 end


### PR DESCRIPTION
[[管理画面] 良い感じにする - タグについて](https://github.com/hr-dash/hr-dash/issues/174#issuecomment-206879747)

管理画面の操作で
- タグを削除できないようにした
- タグの登録・編集時にステータスをテキストボックス→セレクトボックス入力にした
