### PR TITLE
Customize admin user #174

### DIFF
--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -1,6 +1,7 @@
 ActiveAdmin.register User do
   menu parent: 'ユーザー'
   csv_importable validate: false
+  actions :all, except: [:destroy]
   permit_params :name, :group_id, :employee_code, :email, :entry_date, :beginner_flg,
                 :deleted_at, :password, :password_confirmation
 
@@ -8,19 +9,17 @@ ActiveAdmin.register User do
     selectable_column
     id_column
     column :name
-    column :group_id
+    column :group
     column :employee_code
     column :email
     column :entry_date
     column :beginner_flg
     column :deleted_at
-    column :created_at
-    column :updated_at
     actions
   end
 
   filter :name
-  filter :group_id
+  filter :group
   filter :employee_code
   filter :email
   filter :entry_date
@@ -35,11 +34,9 @@ ActiveAdmin.register User do
       f.input :group
       f.input :employee_code
       f.input :email
-      f.input :entry_date
+      f.input :entry_date, as: :datepicker
       f.input :beginner_flg
-      f.input :deleted_at
-      f.input :password
-      f.input :password_confirmation
+      f.input :deleted_at, as: :datepicker
     end
     f.actions
   end


### PR DESCRIPTION
[[管理画面] 良い感じにする - ユーザーについて](https://github.com/hr-dash/hr-dash/issues/174#issuecomment-207723548)

ユーザー管理画面の操作で

**一覧画面***
- ユーザーを削除できないようにした
- グループはidではなくグループ名（リンク付き）を表示
- グループ検索条件はid指定でなくグループを選択
- created_at, updated_atは非表示

**登録・編集画面***
- 入社日、退社日をdatepickerに
- パスワードはここで編集させない
