### PR TITLE
Dev/149 display this month goals

### DIFF
--- a/app/controllers/monthly_reports_controller.rb
+++ b/app/controllers/monthly_reports_controller.rb
@@ -15,7 +15,7 @@ class MonthlyReportsController < ApplicationController
 
   def new
     target_month = params[:target_month] || Date.current.last_month.beginning_of_month
-    @monthly_report = MonthlyReport.new(target_month: target_month)
+    @monthly_report = current_user.monthly_reports.build(target_month: target_month)
   end
 
   def create

--- a/app/models/help_text.rb
+++ b/app/models/help_text.rb
@@ -5,10 +5,19 @@ class HelpText < ActiveRecord::Base
   validates :body, presence: true
 
   scope :placeholder, -> { where(help_type: :placeholder) }
+  scope :hint, -> { where(help_type: :hint) }
 
   def self.placeholders(category)
     where(category: category)
       .placeholder
+      .pluck(:target, :body)
+      .to_h
+      .symbolize_keys
+  end
+
+  def self.hints(category)
+    where(category: category)
+      .hint
       .pluck(:target, :body)
       .to_h
       .symbolize_keys

--- a/app/models/monthly_report.rb
+++ b/app/models/monthly_report.rb
@@ -54,7 +54,7 @@ class MonthlyReport < ActiveRecord::Base
   end
 
   def this_month_goals
-    prev_month&.next_month_goals
+    prev_month.try!(:next_month_goals)
   end
 
   private

--- a/app/models/monthly_report.rb
+++ b/app/models/monthly_report.rb
@@ -53,6 +53,10 @@ class MonthlyReport < ActiveRecord::Base
     self.class.find_by(user: user, target_month: target_month.next_month)
   end
 
+  def this_month_goals
+    prev_month&.next_month_goals
+  end
+
   private
 
   def registrable_term_from

--- a/app/models/monthly_report.rb
+++ b/app/models/monthly_report.rb
@@ -46,10 +46,12 @@ class MonthlyReport < ActiveRecord::Base
   end
 
   def prev_month
+    return unless target_month
     self.class.find_by(user: user, target_month: target_month.prev_month)
   end
 
   def next_month
+    return unless target_month
     self.class.find_by(user: user, target_month: target_month.next_month)
   end
 

--- a/app/views/monthly_reports/_form.html.slim
+++ b/app/views/monthly_reports/_form.html.slim
@@ -5,6 +5,7 @@
         li.text-danger = message
   = form_for monthly_report, html: { class: 'form-horizontal' } do |f|
     - placeholders = HelpText.placeholders(:monthly_report)
+    - hints = HelpText.hints(:monthly_report)
     .form-group
       = f.label :project_summary, class: 'control-label col-xs-3'
       .col-xs-9
@@ -27,9 +28,9 @@
       .col-xs-9
         == render 'layouts/markdown_editor', attr: :business_content, form: f, placeholder: placeholders[:business_content]
     .form-group
-      = label_tag :last_month_goals, '今月の目標', class: 'control-label col-xs-3'
+      = label_tag :this_month_goals, '今月の目標', class: 'control-label col-xs-3'
       .col-xs-9
-        pre.form-control-static = monthly_report.this_month_goals || "先月の月報が入力されていません。\n先月の月報の「来月の目標」が表示されます。"
+        pre.form-control-static = monthly_report.this_month_goals || hints[:this_month_goals]
     .form-group
       = f.label :looking_back, class: 'control-label col-xs-3'
       .col-xs-9

--- a/app/views/monthly_reports/_form.html.slim
+++ b/app/views/monthly_reports/_form.html.slim
@@ -29,7 +29,7 @@
     .form-group
       = label_tag :last_month_goals, '今月の目標', class: 'control-label col-xs-3'
       .col-xs-9
-        p.form-control-static 先月、「来月の目標」に書いた内容を表示
+        pre.form-control-static = monthly_report.this_month_goals || "先月の月報が入力されていません。\n先月の月報の「来月の目標」が表示されます。"
     .form-group
       = f.label :looking_back, class: 'control-label col-xs-3'
       .col-xs-9

--- a/app/views/monthly_reports/_form.html.slim
+++ b/app/views/monthly_reports/_form.html.slim
@@ -30,7 +30,9 @@
     .form-group
       = label_tag :this_month_goals, '今月の目標', class: 'control-label col-xs-3'
       .col-xs-9
-        pre.form-control-static = monthly_report.this_month_goals || hints[:this_month_goals]
+        .form-control-static
+          - this_month_goals = monthly_report.this_month_goals.presence || hints[:this_month_goals]
+          = render 'layouts/markdown_view', content: this_month_goals
     .form-group
       = f.label :looking_back, class: 'control-label col-xs-3'
       .col-xs-9

--- a/app/views/monthly_reports/show.html.slim
+++ b/app/views/monthly_reports/show.html.slim
@@ -33,6 +33,9 @@
           label.col-xs-3.control-label = t "#{attr}.business_content"
           .col-xs-9.form-control-static
             = render 'layouts/markdown_view', content: @monthly_report.business_content
+          label.col-xs-3.control-label 今月の目標
+          .col-xs-9.form-control-static
+            = render 'layouts/markdown_view', content: @monthly_report.this_month_goals
           label.col-xs-3.control-label = t "#{attr}.looking_back"
           .col-xs-9.form-control-static
             = render 'layouts/markdown_view', content: @monthly_report.looking_back

--- a/db/seeds/help_text.yml
+++ b/db/seeds/help_text.yml
@@ -35,3 +35,10 @@
   body: "例）\r\n1. \r\n2. \r\n3."
   created_at: 2016-04-17 04:03:04.259770000 Z
   updated_at: 2016-04-17 04:03:58.588447000 Z
+- id: 6
+  category: monthly_report
+  help_type: hint
+  target: this_month_goals
+  body: "先月の月報が入力されていません。\r\n先月の月報の「来月の目標」が表示されます。"
+  created_at: 2016-04-17 04:03:04.259770000 Z
+  updated_at: 2016-04-17 04:03:58.588447000 Z

--- a/spec/factories/help_texts.rb
+++ b/spec/factories/help_texts.rb
@@ -8,5 +8,9 @@ FactoryGirl.define do
     trait :placeholder do
       help_type { 'placeholder' }
     end
+
+    trait :hint do
+      help_type { 'hint' }
+    end
   end
 end

--- a/spec/models/help_text_spec.rb
+++ b/spec/models/help_text_spec.rb
@@ -29,4 +29,25 @@ describe HelpText, type: :model do
       it { is_expected.to eq result }
     end
   end
+
+  describe '.hints' do
+    let!(:help_text) { create(:help_text, :hint) }
+    subject { described_class.hints(category) }
+
+    context 'match category' do
+      let(:category) { help_text.category }
+      let(:target) { help_text.target }
+      let(:body) { help_text.body }
+      let(:result) { { target.to_sym => body } }
+      it { is_expected.not_to be_blank }
+      it { is_expected.to eq result }
+    end
+
+    context 'not match category' do
+      let(:category) { 'invalid category' }
+      let(:result) { {} }
+      it { is_expected.to be_blank }
+      it { is_expected.to eq result }
+    end
+  end
 end

--- a/spec/models/monthly_report_spec.rb
+++ b/spec/models/monthly_report_spec.rb
@@ -92,4 +92,21 @@ RSpec.describe MonthlyReport, type: :model do
       end
     end
   end
+
+  describe '#this_month_goals' do
+    let(:user) { create(:user) }
+    let(:report) { create(:monthly_report, user: user) }
+    subject { report.this_month_goals }
+
+    context 'not exist last month report' do
+      it { is_expected.to be_nil }
+    end
+
+    context 'exist last month report' do
+      let(:last_month) { report.target_month.prev_month }
+      before { create(:monthly_report, user: user, target_month: last_month) }
+
+      it { is_expected.not_to be_nil }
+    end
+  end
 end


### PR DESCRIPTION
[[月報登録] 今月の目標が表示されるようにする](https://github.com/hr-dash/hr-dash/issues/149)

`MonthlyReport#prev_month`を引くために`user`をセットしたり、`target_month`が無い時はガードしたりする箇所を追加した。

[ヘルプテキスト](https://github.com/hr-dash/hr-dash/pull/200)が先にマージされたら、先月の月報が無い時の表示はヘルプテキストに移す。
こっちが先にマージされたら、ヘルプテキストのPRを編集する。
