### PR TITLE
Add length validation for textarea

### DIFF
--- a/app/models/monthly_report.rb
+++ b/app/models/monthly_report.rb
@@ -24,6 +24,10 @@ class MonthlyReport < ActiveRecord::Base
 
   validates :user, presence: true
   validates :target_month, presence: true
+  validates :project_summary, length: { maximum: 5000 }
+  validates :business_content, length: { maximum: 5000 }
+  validates :looking_back, length: { maximum: 5000 }
+  validates :next_month_goals, length: { maximum: 5000 }
   validate :target_beginning_of_month?
   validate :target_month_registrable_term
   validate :uniq_by_user_and_target_month, on: :create

--- a/spec/models/monthly_report_spec.rb
+++ b/spec/models/monthly_report_spec.rb
@@ -22,6 +22,10 @@ RSpec.describe MonthlyReport, type: :model do
     it { is_expected.to be_valid }
     it { is_expected.to validate_presence_of(:user) }
     it { is_expected.to validate_presence_of(:target_month) }
+    it { is_expected.to validate_length_of(:project_summary).is_at_most(5000) }
+    it { is_expected.to validate_length_of(:business_content).is_at_most(5000) }
+    it { is_expected.to validate_length_of(:looking_back).is_at_most(5000) }
+    it { is_expected.to validate_length_of(:next_month_goals).is_at_most(5000) }
 
     describe '#target_beginning_of_month?' do
       let(:invalid_target) { Faker::Date.backward(100).end_of_month }


### PR DESCRIPTION
[[月報] textareaに大量の文字を入力するとエラー](https://github.com/hr-dash/hr-dash/issues/171)

月報のテキストエリアで入力する項目について、5000字の制限を追加
