### PR TITLE
Dev/158 search customize

### DIFF
--- a/app/controllers/monthly_reports_controller.rb
+++ b/app/controllers/monthly_reports_controller.rb
@@ -1,6 +1,6 @@
 class MonthlyReportsController < ApplicationController
   def index
-    @q = MonthlyReport.ransack(params[:q])
+    @q = MonthlyReport.ransack(search_params)
     @monthly_reports = @q.result.released.page params[:page]
   end
 
@@ -89,5 +89,14 @@ class MonthlyReportsController < ApplicationController
       :looking_back,
       :next_month_goals,
     )
+  end
+
+  def search_params
+    return unless params[:q]
+
+    search_conditions = %i(
+      user_group_id_eq user_name_cont
+    )
+    params.require(:q).permit(search_conditions)
   end
 end

--- a/app/controllers/monthly_reports_controller.rb
+++ b/app/controllers/monthly_reports_controller.rb
@@ -1,7 +1,7 @@
 class MonthlyReportsController < ApplicationController
   def index
-    users = User.where('name LIKE ?', "%#{params[:name]}%")
-    @monthly_reports = MonthlyReport.released.where(user: users).page params[:page]
+    @q = MonthlyReport.ransack(params[:q])
+    @monthly_reports = @q.result.released.page params[:page]
   end
 
   def mine

--- a/app/views/monthly_reports/index.html.slim
+++ b/app/views/monthly_reports/index.html.slim
@@ -3,8 +3,14 @@
 .page-content
   .jumbotron
     .container
-      h3 名前検索
-      == render partial: 'layouts/search_form', locals: { path: monthly_reports_path, param: :name }
+      = form_tag monthly_reports_path, method: :get, class: 'form-horizontal'
+        .form-group
+          .col-xs-10
+          label.control-label.col-xs-2 for="searchByName" 氏名
+            = text_field_tag :name, nil, id: 'searchByName', class: 'form-control'
+        .form-group
+          .col-xs-10.col-xs-offset-2
+            button.btn.btn-default 検索
 .page-content
   h3 最新の月報一覧
   #report_index

--- a/app/views/monthly_reports/index.html.slim
+++ b/app/views/monthly_reports/index.html.slim
@@ -1,8 +1,10 @@
 - provide :page_title, "月報トップ"
 
 .page-content
-  h3 名前検索
-  == render partial: 'layouts/search_form', locals: { path: monthly_reports_path, param: :name }
+  .jumbotron
+    .container
+      h3 名前検索
+      == render partial: 'layouts/search_form', locals: { path: monthly_reports_path, param: :name }
 .page-content
   h3 最新の月報一覧
   #report_index

--- a/app/views/monthly_reports/index.html.slim
+++ b/app/views/monthly_reports/index.html.slim
@@ -3,14 +3,18 @@
 .page-content
   .jumbotron
     .container
-      = form_tag monthly_reports_path, method: :get, class: 'form-horizontal'
+      = search_form_for @q, { class: 'form-horizontal' } do |f|
         .form-group
+          = f.label :user_group_id_eq, 'グループ', class: 'control-label col-xs-2'
           .col-xs-10
-          label.control-label.col-xs-2 for="searchByName" 氏名
-            = text_field_tag :name, nil, id: 'searchByName', class: 'form-control'
+            = f.select :user_group_id_eq, options_for_select(Group.pluck(:name, :id), selected: @q.user_group_id_eq), { include_blank: true }, class: 'form-control'
+        .form-group
+          = f.label :user_name_cont, '氏名', class: 'control-label col-xs-2'
+          .col-xs-10
+            = f.search_field :user_name_cont, class: 'form-control'
         .form-group
           .col-xs-10.col-xs-offset-2
-            button.btn.btn-default 検索
+            = f.button '検索', class: 'btn btn-default'
 .page-content
   h3 最新の月報一覧
   #report_index


### PR DESCRIPTION
[[検索] 月報をグループで絞り込めるようにする](https://github.com/hr-dash/hr-dash/issues/158)
- 検索フィールドをまとめるためjumbotronを使用
- 月報の検索項目にグループを追加
- 検索項目は今後も増えるので、よりシンプルに書けるransackを使用

https://github.com/activerecord-hackery/ransack

ActiveAdmin内で使っているので、Gemの追加は不要
