### PR TITLE
Dev/147 search customize for tags

### DIFF
--- a/app/controllers/monthly_reports_controller.rb
+++ b/app/controllers/monthly_reports_controller.rb
@@ -97,6 +97,8 @@ class MonthlyReportsController < ApplicationController
     search_conditions = %i(
       user_group_id_eq user_name_cont
     )
+
+    params[:q][:tags_name_in] = params[:q][:tags_name_in].split(',')
     params.require(:q).permit(search_conditions)
   end
 end

--- a/app/controllers/monthly_reports_controller.rb
+++ b/app/controllers/monthly_reports_controller.rb
@@ -99,6 +99,7 @@ class MonthlyReportsController < ApplicationController
       :user_group_id_eq,
       :user_name_cont,
       tags_name_in: [],
+      monthly_working_processes_process_in: [],
     ]
 
     params.require(:q).permit(search_conditions)

--- a/app/controllers/monthly_reports_controller.rb
+++ b/app/controllers/monthly_reports_controller.rb
@@ -93,12 +93,14 @@ class MonthlyReportsController < ApplicationController
 
   def search_params
     return unless params[:q]
-
-    search_conditions = %i(
-      user_group_id_eq user_name_cont
-    )
-
     params[:q][:tags_name_in] = params[:q][:tags_name_in].split(',')
+
+    search_conditions = [
+      :user_group_id_eq,
+      :user_name_cont,
+      tags_name_in: [],
+    ]
+
     params.require(:q).permit(search_conditions)
   end
 end

--- a/app/controllers/monthly_reports_controller.rb
+++ b/app/controllers/monthly_reports_controller.rb
@@ -1,7 +1,7 @@
 class MonthlyReportsController < ApplicationController
   def index
     @q = MonthlyReport.ransack(search_params)
-    @monthly_reports = @q.result.released.page params[:page]
+    @monthly_reports = @q.result(distinct: true).released.page params[:page]
   end
 
   def mine

--- a/app/views/layouts/_monthly_report_tags.html.erb
+++ b/app/views/layouts/_monthly_report_tags.html.erb
@@ -10,6 +10,7 @@ $(function(){
   var tagger = $('#monthly_report_tags').tags({
       tagData: <%= (tags.present? ? tags.map(&:name) : []).to_json.html_safe %>,
       suggestions: <%= Tag.fixed.pluck(:name).to_json.html_safe %>,
+      suggestOnClick: true,
       caseInsensitive: true,
       tagClass: 'btn-success',
       afterAddingTag: function() {

--- a/app/views/layouts/_monthly_report_tags.html.erb
+++ b/app/views/layouts/_monthly_report_tags.html.erb
@@ -8,7 +8,7 @@ $(function(){
   }
 
   var tagger = $('#monthly_report_tags').tags({
-      tagData: <%= (tags.present? ? tags.map(&:name) : []).to_json.html_safe %>,
+      tagData: <%= tags.to_json.html_safe %>,
       suggestions: <%= Tag.fixed.pluck(:name).to_json.html_safe %>,
       suggestOnClick: true,
       caseInsensitive: true,

--- a/app/views/monthly_reports/_form.html.slim
+++ b/app/views/monthly_reports/_form.html.slim
@@ -14,7 +14,7 @@
       = f.label :monthly_report_tags, class: 'control-label col-xs-3'
       .col-xs-9
         = f.hidden_field :monthly_report_tags, id: :monthly_report_tags_input, class: 'form-control'
-        == render 'layouts/monthly_report_tags', tags: monthly_report.monthly_report_tags, placeholder: placeholders[:tags]
+        == render 'layouts/monthly_report_tags', tags: monthly_report.monthly_report_tags.map(&:name), placeholder: placeholders[:tags]
     .form-group
       = f.label :monthly_working_processes, class: 'control-label col-xs-3'
       .col-xs-9.btn-group data-toggle="buttons"

--- a/app/views/monthly_reports/index.html.slim
+++ b/app/views/monthly_reports/index.html.slim
@@ -17,7 +17,7 @@
           = f.label :tags_name_in, '使用した技術', class: 'control-label col-xs-2'
           .col-xs-10
             = f.hidden_field :tags_name_in, id: :monthly_report_tags_input, class: 'form-control'
-            == render 'layouts/monthly_report_tags', tags: nil, placeholder: placeholders[:tags]
+            == render 'layouts/monthly_report_tags', tags: @q.tags_name_in, placeholder: placeholders[:tags]
         .form-group
           .col-xs-10.col-xs-offset-2
             = f.button '検索', class: 'btn btn-default'

--- a/app/views/monthly_reports/index.html.slim
+++ b/app/views/monthly_reports/index.html.slim
@@ -1,4 +1,5 @@
 - provide :page_title, "月報トップ"
+- placeholders = HelpText.placeholders(:monthly_report)
 
 .page-content
   .jumbotron
@@ -12,6 +13,11 @@
           = f.label :user_name_cont, '氏名', class: 'control-label col-xs-2'
           .col-xs-10
             = f.search_field :user_name_cont, class: 'form-control'
+        .form-group
+          = f.label :tags_name_in, '使用した技術', class: 'control-label col-xs-2'
+          .col-xs-10
+            = f.hidden_field :tags_name_in, id: :monthly_report_tags_input, class: 'form-control'
+            == render 'layouts/monthly_report_tags', tags: nil, placeholder: placeholders[:tags]
         .form-group
           .col-xs-10.col-xs-offset-2
             = f.button '検索', class: 'btn btn-default'

--- a/app/views/monthly_reports/index.html.slim
+++ b/app/views/monthly_reports/index.html.slim
@@ -19,6 +19,14 @@
             = f.hidden_field :tags_name_in, id: :monthly_report_tags_input, class: 'form-control'
             == render 'layouts/monthly_report_tags', tags: @q.tags_name_in, placeholder: placeholders[:tags]
         .form-group
+          = f.label :monthly_working_processes_process_in, '担当した工程', class: 'control-label col-xs-2'
+          .col-xs-10.btn-group data-toggle="buttons"
+            - MonthlyWorkingProcess.processes.each do |key, value|
+              - working_process = MonthlyWorkingProcess.new(process: value)
+              label.btn.btn-default class=('active' if @q.monthly_working_processes_process_in.try!(:include?, value))
+                = f.check_box :monthly_working_processes_process_in, { multiple: true, autocomplete: "off" }, value, nil
+                span = working_process.process_i18n
+        .form-group
           .col-xs-10.col-xs-offset-2
             = f.button '検索', class: 'btn btn-default'
 .page-content


### PR DESCRIPTION
## 前提

https://github.com/hr-dash/hr-dash/pull/208
月報検索にransackを使うことが前提になっているので、こっち↑が先
## 本PRの対応

[[検索] タグで検索できるようにする](https://github.com/hr-dash/hr-dash/issues/147)
[[検索] 工程で検索できるようにする](https://github.com/hr-dash/hr-dash/issues/148)
- 検索項目に「使用した技術」を追加
- 使用した技術のフィールドをクリックした時、自動でsuggestionが開くように（月報入力時も同様）
- 検索項目に「担当した工程」を追加
- 検索結果として複数行でないように`:distinct`オプションを追加
### 懸念点

というか、ちょっと気持ち悪い点として、
- 使用した技術
- 担当した工程

はそれぞれ複数個入力できるようになっているけど、それぞれが「OR」条件になってしまっている。
例えば、`java`と`ruby`で検索すると、両方のタグを持ってる月報ではなくどちらかのタグを持っていれば検索結果として出力されてしまう。
- 多分だけどデフォルトのransackの機能ではできなくて、カスタムマッチャみたいなのを作らないといけない
- もしくは取得したActiveRecordをRubyでいじってAND条件を満たす月報に絞る
- いずれにせよそこそこのボリュームなので、やるとしたら別Issueとしたい

誰かこうやればすっきり書ける！みたいなのわかったら教えてください…
