### PR TITLE
Set .tags in bootstrap-tags position: relative

### DIFF
--- a/app/views/layouts/_monthly_report_tags_show.html.erb
+++ b/app/views/layouts/_monthly_report_tags_show.html.erb
@@ -3,10 +3,14 @@
 
 <script>
 $(function(){
-  $('#<%= taglist_id %>').tags({
+  var target = $('#<%= taglist_id %>');
+
+  target.tags({
     readOnly: true,
     tagData: <%= raw (tags.present? ? tags.map(&:name) : []) %>,
     tagClass: 'btn-success',
   });
+
+  target.find('.tags').css('position', 'relative');
 });
 </script>


### PR DESCRIPTION
[[月報] show レイアウトが大きく崩れる](https://github.com/hr-dash/hr-dash/issues/162)

レイアウトが大きく崩れるって、このことでいいんだよな…？
### Before

<img width="764" alt="2016-05-05 22 12 21" src="https://cloud.githubusercontent.com/assets/2487437/15044613/bd04755e-1310-11e6-990e-afdbad7c6076.png">
### After

<img width="752" alt="2016-05-05 22 24 53" src="https://cloud.githubusercontent.com/assets/2487437/15044614/c3bb1592-1310-11e6-974a-a02872152dc5.png">
### 原因

タグに使用しているbootstrapのライブラリ（ https://github.com/maxwells/bootstrap-tags ）で、タグを作成した時に、指定したdiv内に`<div class="tags">`が作成されるが、何故かその作成されたタグが`position: absolute`になっていて、それが原因。
absoluteにしている理由は不明。
ちなみに、指定したdivには`position: relative`が付与される。
### 解決方法

`.tags`には`position: relative`を指定する（タグ作成後）
