### PR TITLE
Set z-index of .bootstrap-tags suggestion to 3

### DIFF
--- a/app/assets/stylesheets/bootstrap-tags.css
+++ b/app/assets/stylesheets/bootstrap-tags.css
@@ -59,7 +59,7 @@
     height: auto;
     list-style: none;
     margin: 0;
-    z-index: 2;
+    z-index: 3;
     max-height: 160px;
     overflow: scroll; }
     .bootstrap-tags ul.tags-suggestion-list li.tags-suggestion {


### PR DESCRIPTION
[対応した工程を選択後、使用した技術のプルダウンを表示するとプルダウンが後ろにきてみえない](https://github.com/hr-dash/hr-dash/issues/210)
## 対処法

<img width="316" alt="2016-05-06 20 56 19" src="https://cloud.githubusercontent.com/assets/2487437/15072387/5be7b6f6-13cd-11e6-9a94-35e64f147078.png">

`btn.active`が2でセットされているのでそれを上回るよう修正
