### PR TITLE
Dev/157 profile link

### DIFF
--- a/app/views/layouts/_group_tab.html.slim
+++ b/app/views/layouts/_group_tab.html.slim
@@ -13,5 +13,5 @@ div.row.group-tab
         .col-md-5
           h5 メンバー
           - group.users.each do |user|
-            p = user.name
+            p = link_to user.name, user_profile_path(user.user_profile)
   

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,6 +1,7 @@
 [
   ActiveAdminActionLog,
   User,
+  Group,
   MonthlyReport,
   Tag,
   HelpText,


### PR DESCRIPTION
[グループからプロフィール、プロフィールからそのユーザーの月報一覧へのリンクをつける](https://github.com/hr-dash/hr-dash/issues/157)

ひとまずグループページのメンバー名→プロフィールへのリンク追加
ついでに、DBのSEEDリセットする時にGroupを消せていなかったのでGroupも削除
