### PR TITLE
Tags order by id, restrict 3 records in report index

### DIFF
--- a/app/views/layouts/_report_index.html.slim
+++ b/app/views/layouts/_report_index.html.slim
@@ -3,5 +3,6 @@
     a.list-group-item href=(monthly_report_path(report))
       = "#{report.user.group.name}G | #{report.user.name} - #{report.target_month.strftime("%Y年%m月")}分"
       - # span.glyphicon.glyphicon-thumbs-up.pull-right aria-hidden="true" = 11
-      - report.monthly_report_tags.each do |tag|
+      - tags = report.monthly_report_tags.order('monthly_report_tags.id')
+      - tags.first(3).each do |tag|
         span.badge = tag.name


### PR DESCRIPTION
[月報一覧でタグ多すぎな時、レイアウトが崩れる](https://github.com/hr-dash/hr-dash/issues/215)
- タグの表示を3つまでに限定
