### PR TITLE
Dev/169 select target month

### DIFF
--- a/app/models/monthly_report.rb
+++ b/app/models/monthly_report.rb
@@ -75,7 +75,7 @@ class MonthlyReport < ActiveRecord::Base
     return if user.blank?
     return if target_month.blank?
     return if registrable_term?
-    errors.add :target_month, " must included by user.report_registrable_months"
+    errors.add :target_month, ' must included by user.report_registrable_months'
   end
 
   def target_beginning_of_month?

--- a/app/models/monthly_report.rb
+++ b/app/models/monthly_report.rb
@@ -40,11 +40,8 @@ class MonthlyReport < ActiveRecord::Base
   before_save :log_shipped_at
 
   def registrable_term?
-    registrable_term.cover? target_month
-  end
-
-  def registrable_term
-    registrable_term_from..registrable_term_to
+    return false unless user
+    user.registrable_term.cover? target_month
   end
 
   def prev_month
@@ -74,19 +71,11 @@ class MonthlyReport < ActiveRecord::Base
 
   private
 
-  def registrable_term_from
-    user.entry_date.beginning_of_month
-  end
-
-  def registrable_term_to
-    Time.current.last_month.since(5.days)
-  end
-
   def target_month_registrable_term
     return if user.blank?
     return if target_month.blank?
     return if registrable_term?
-    errors.add :target_month, " must be #{registrable_term}"
+    errors.add :target_month, " must be #{user.registrable_term}"
   end
 
   def target_beginning_of_month?

--- a/app/models/monthly_report.rb
+++ b/app/models/monthly_report.rb
@@ -41,7 +41,7 @@ class MonthlyReport < ActiveRecord::Base
 
   def registrable_term?
     return false unless user
-    user.registrable_term.cover? target_month
+    user.report_registrable_months.include? target_month
   end
 
   def prev_month
@@ -75,7 +75,7 @@ class MonthlyReport < ActiveRecord::Base
     return if user.blank?
     return if target_month.blank?
     return if registrable_term?
-    errors.add :target_month, " must be #{user.registrable_term}"
+    errors.add :target_month, " must included by user.report_registrable_months"
   end
 
   def target_beginning_of_month?

--- a/app/models/monthly_report.rb
+++ b/app/models/monthly_report.rb
@@ -35,8 +35,6 @@ class MonthlyReport < ActiveRecord::Base
   scope :year, ->(year) { where(target_month: (Time.zone.local(year))..(Time.zone.local(year).end_of_year)) }
   scope :released, -> { where.not(shipped_at: nil) }
 
-  REGISTRABLE_TERM_FROM = Time.local(2000, 1, 1)
-
   enum status: { wip: 0, shipped: 1 }
 
   before_save :log_shipped_at
@@ -77,7 +75,7 @@ class MonthlyReport < ActiveRecord::Base
   private
 
   def registrable_term_from
-    REGISTRABLE_TERM_FROM
+    user.entry_date.beginning_of_month
   end
 
   def registrable_term_to
@@ -85,6 +83,7 @@ class MonthlyReport < ActiveRecord::Base
   end
 
   def target_month_registrable_term
+    return if user.blank?
     return if target_month.blank?
     return if registrable_term?
     errors.add :target_month, " must be #{registrable_term}"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -41,7 +41,19 @@ class User < ActiveRecord::Base
   devise :database_authenticatable,
          :recoverable, :rememberable, :trackable, :validatable
 
+  def registrable_term
+    registrable_term_from..registrable_term_to
+  end
+
   private
+
+  def report_registrable_from
+    entry_date.beginning_of_month
+  end
+
+  def report_registrable_to
+    Time.current.last_month.since(5.days)
+  end
 
   def create_profile
     UserProfile.create!(user_id: id)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -41,8 +41,16 @@ class User < ActiveRecord::Base
   devise :database_authenticatable,
          :recoverable, :rememberable, :trackable, :validatable
 
-  def registrable_term
-    registrable_term_from..registrable_term_to
+  def report_registrable_months
+    months = []
+    month = report_registrable_from
+
+    while month <= report_registrable_to
+      months << month
+      month = month.next_month
+    end
+
+    months
   end
 
   private

--- a/app/views/monthly_reports/_form.html.slim
+++ b/app/views/monthly_reports/_form.html.slim
@@ -11,6 +11,14 @@
     - placeholders = HelpText.placeholders(:monthly_report)
     - hints = HelpText.hints(:monthly_report)
     .form-group
+      = f.label :target_month, class: 'control-label col-xs-3'
+      .col-xs-9
+        select#monthly_report_target_month.form-control onchange='location.href=this.selectedOptions[0].getAttribute("href")'
+          - current_user.report_registrable_months.each do |m|
+            - report = current_user.monthly_reports.find_or_initialize_by(target_month: m)
+            - path = report.new_record? ? new_monthly_report_path(target_month: m) : edit_monthly_report_path(report)
+            option value=(m) href=(path) selected=(true if monthly_report.target_month == m) = m.strftime('%Y月%m月')
+    .form-group
       = f.label :project_summary, class: 'control-label col-xs-3'
       .col-xs-9
         == render 'layouts/markdown_editor', attr: :project_summary, form: f, placeholder: placeholders[:project_summary]

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -5,7 +5,7 @@ FactoryGirl.define do
     sequence(:employee_code) { |i| "#{i}#{Faker::Number.number(10)}" }
     sequence(:email) { |i| "#{i}#{Faker::Internet.email}" }
     password { Faker::Internet.password(8) }
-    entry_date { Faker::Date.between(3.years.ago, Date.today) }
+    entry_date { Faker::Date.between(3.years.ago, 1.year.ago) }
     beginner_flg { [true, false].sample }
   end
 end

--- a/spec/models/monthly_report_spec.rb
+++ b/spec/models/monthly_report_spec.rb
@@ -35,10 +35,11 @@ RSpec.describe MonthlyReport, type: :model do
     end
 
     describe '#target_month_registrable_term' do
-      let(:monthly_report) { build(:monthly_report, target_month: invalid_target) }
+      let(:user) { create(:user) }
+      let(:monthly_report) { build(:monthly_report, user: user, target_month: invalid_target) }
 
       context 'before lower limit' do
-        let(:lower_limit) { Time.local(2000, 1, 1) }
+        let(:lower_limit) { user.entry_date.beginning_of_month }
         let(:invalid_target) { lower_limit.ago(1.day) }
         it { expect(monthly_report).not_to be_valid }
       end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -50,4 +50,27 @@ describe User, type: :model do
     let(:profile) { UserProfile.find_by(user_id: user) }
     it { expect(profile).to be_present }
   end
+
+  describe '#report_registrable_months' do
+    let(:entry_date) { Date.new(2016, 1, 1) }
+    let(:user) { create(:user, entry_date: entry_date) }
+
+    before { Timecop.freeze(today) }
+    after { Timecop.return }
+    subject { user.report_registrable_months }
+
+    context 'when cannot regist this month report' do
+      let(:today) { Date.new(2016, 5, 26) }
+      it { expect(subject.first).to eq entry_date }
+      it { expect(subject.size).to eq 4 }
+      it { expect(subject.last).to eq Date.new(2016, 4, 1) }
+    end
+
+    context 'when can regist this month report' do
+      let(:today) { Date.new(2016, 5, 27) }
+      it { expect(subject.first).to eq entry_date }
+      it { expect(subject.size).to eq 5 }
+      it { expect(subject.last).to eq Date.new(2016, 5, 1) }
+    end
+  end
 end


### PR DESCRIPTION
[[月報登録] 月報のnewで年月が選択できるようにする](https://github.com/hr-dash/hr-dash/issues/169)
- 月報の登録可能月を　固定値→入社月〜　に変更
- 登録可能月のロジックをUserに持たせるよう変更
- 月報入力画面で対象月を選択可能にする
  - 別の月が選択された際、リダイレクトさせる
  - 登録済の月ならedit, そうでなければnewのURLにリダイレクト
