### PR TITLE
Dev/142 validate monthly report

### DIFF
--- a/app/models/monthly_report.rb
+++ b/app/models/monthly_report.rb
@@ -31,6 +31,16 @@ class MonthlyReport < ActiveRecord::Base
   validate :target_beginning_of_month?
   validate :target_month_registrable_term
   validate :uniq_by_user_and_target_month, on: :create
+  with_options if: :shipped? do
+    validates :project_summary, presence: true
+    validates :business_content, presence: true
+    validates :looking_back, presence: true
+    validates :next_month_goals, presence: true
+    validates :monthly_report_tags, presence: true
+    validates :monthly_working_processes, presence: true
+  end
+
+  validates_associated :monthly_report_tags
 
   scope :year, ->(year) { where(target_month: (Time.zone.local(year))..(Time.zone.local(year).end_of_year)) }
   scope :released, -> { where.not(shipped_at: nil) }

--- a/spec/factories/monthly_report.rb
+++ b/spec/factories/monthly_report.rb
@@ -1,16 +1,12 @@
 FactoryGirl.define do
   factory :monthly_report do
     association :user
-    status { MonthlyReport.statuses[:shipped] }
+    status { MonthlyReport.statuses[:wip] }
     target_month { Faker::Date.between(6.months.ago, 1.months.ago).beginning_of_month }
     project_summary { Faker::Lorem.paragraph }
     business_content { Faker::Lorem.paragraph }
     looking_back { Faker::Lorem.paragraph }
     next_month_goals { Faker::Lorem.paragraph }
-
-    after(:create) do |report|
-      create(:monthly_working_process, monthly_report: report)
-    end
 
     trait :wip do
       status { MonthlyReport.statuses[:wip] }
@@ -37,11 +33,19 @@ FactoryGirl.define do
         tag_size 3
       end
 
-      after(:create) do |report, evaluator|
+      after(:build) do |report, evaluator|
         evaluator.tag_size.times do
-          create(:monthly_report_tag, monthly_report: report)
+          report.monthly_report_tags << build(:monthly_report_tag, monthly_report: report)
         end
       end
     end
+
+    trait :with_working_processes do
+      after(:build) do |report|
+        report.monthly_working_processes << build(:monthly_working_process, monthly_report: report)
+      end
+    end
+
+    factory :shipped_montly_report, traits: [:shipped, :with_tags, :with_working_processes]
   end
 end


### PR DESCRIPTION
## MonthlyReportにバリデーションを追加
- `MonthlyReport.status`が1(shipped)の場合に各項目が入力されていなければinvalid
  - プロジェクト概要（`MonthlyReport.project_summary`）
  - 使用した技術（`MonthlyReportTag`）
  - 担当した工程（`MonthlyWorkingProcess`）
  - 業務内容（`MonthlyReport.business_content`）
  - 今月の振り返り（`MonthlyReport.looking_back`）
  - 来月の目標（`MonthlyReport.next_month_goals`）
- `MonthlyReport.status`が0(wip)のならば追加検証なし
