### PR TITLE
Dev/239 monthly report errors

### DIFF
--- a/app/assets/stylesheets/style.css.scss
+++ b/app/assets/stylesheets/style.css.scss
@@ -64,3 +64,8 @@ html, body, .site-body, .site-container, .site-header, .header-menu {
     border-top: none;
   }
 }
+
+/* alert message */
+.alert {
+  margin-bottom: 10px;
+}

--- a/app/controllers/monthly_report_comments_controller.rb
+++ b/app/controllers/monthly_report_comments_controller.rb
@@ -35,7 +35,7 @@ class MonthlyReportCommentsController < ApplicationController
   private
 
   def flash_errors(comment)
-    flash[:error] = comment.errors.full_messages
+    flash.now[:error] = comment.errors.full_messages
   end
 
   def comment_path(comment)

--- a/app/controllers/monthly_report_comments_controller.rb
+++ b/app/controllers/monthly_report_comments_controller.rb
@@ -35,7 +35,7 @@ class MonthlyReportCommentsController < ApplicationController
   private
 
   def flash_errors(comment)
-    comment.errors.full_messages.each { |msg| flash[:error] = msg }
+    flash[:error] = comment.errors.full_messages
   end
 
   def comment_path(comment)

--- a/app/controllers/monthly_reports_controller.rb
+++ b/app/controllers/monthly_reports_controller.rb
@@ -28,7 +28,7 @@ class MonthlyReportsController < ApplicationController
     if @monthly_report.save
       redirect_to @monthly_report
     else
-      flash[:error] = @monthly_report.errors.full_messages
+      flash.now[:error] = @monthly_report.errors.full_messages
       render :new
     end
   end
@@ -45,7 +45,7 @@ class MonthlyReportsController < ApplicationController
     if @monthly_report.save
       redirect_to @monthly_report
     else
-      flash[:error] = @monthly_report.errors.full_messages
+      flash.now[:error] = @monthly_report.errors.full_messages
       render :edit
     end
   end

--- a/app/controllers/monthly_reports_controller.rb
+++ b/app/controllers/monthly_reports_controller.rb
@@ -28,7 +28,7 @@ class MonthlyReportsController < ApplicationController
     if @monthly_report.save
       redirect_to @monthly_report
     else
-      flash.now[:error] = @monthly_report.errors.full_messages
+      flash_errors(@monthly_report)
       render :new
     end
   end
@@ -45,7 +45,7 @@ class MonthlyReportsController < ApplicationController
     if @monthly_report.save
       redirect_to @monthly_report
     else
-      flash.now[:error] = @monthly_report.errors.full_messages
+      flash_errors(@monthly_report)
       render :edit
     end
   end
@@ -56,6 +56,10 @@ class MonthlyReportsController < ApplicationController
   end
 
   private
+
+  def flash_errors(monthly_report)
+    flash.now[:error] = monthly_report.errors.full_messages
+  end
 
   def assign_relational_params(report)
     report.status = params[:wip] ? :wip : :shipped

--- a/app/controllers/monthly_reports_controller.rb
+++ b/app/controllers/monthly_reports_controller.rb
@@ -28,6 +28,7 @@ class MonthlyReportsController < ApplicationController
     if @monthly_report.save
       redirect_to @monthly_report
     else
+      flash[:error] = @monthly_report.errors.full_messages
       render :new
     end
   end
@@ -44,6 +45,7 @@ class MonthlyReportsController < ApplicationController
     if @monthly_report.save
       redirect_to @monthly_report
     else
+      flash[:error] = @monthly_report.errors.full_messages
       render :edit
     end
   end

--- a/app/controllers/user_profiles_controller.rb
+++ b/app/controllers/user_profiles_controller.rb
@@ -12,7 +12,7 @@ class UserProfilesController < ApplicationController
     if @profile.update(permitted_params)
       redirect_to @profile
     else
-      @profile.errors.full_messages.each { |msg| flash[:error] = msg }
+      flash[:error] = @profile.errors.full_messages
       render :edit
     end
   end

--- a/app/controllers/user_profiles_controller.rb
+++ b/app/controllers/user_profiles_controller.rb
@@ -12,7 +12,7 @@ class UserProfilesController < ApplicationController
     if @profile.update(permitted_params)
       redirect_to @profile
     else
-      flash[:error] = @profile.errors.full_messages
+      flash.now[:error] = @profile.errors.full_messages
       render :edit
     end
   end

--- a/app/views/layouts/_flash_messages.html.slim
+++ b/app/views/layouts/_flash_messages.html.slim
@@ -1,6 +1,7 @@
-- flash.each do |type, message|
-  .alert.alert-dismissible.fade.in class=(alert_class_for(type))
-    button.close type="button" data-dismiss="alert"
-      span aria-hidden="true" &times;
-      span.sr-only Close
-    = message
+- flash.each do |type, messages|
+  - messages.each do |message|
+    .alert.alert-dismissible.fade.in class=(alert_class_for(type))
+      button.close type="button" data-dismiss="alert"
+        span aria-hidden="true" &times;
+        span.sr-only Close
+      = message

--- a/app/views/monthly_reports/_form.html.slim
+++ b/app/views/monthly_reports/_form.html.slim
@@ -1,9 +1,4 @@
 .page-content.well
-  - if monthly_report.errors.present?
-    ul
-      - monthly_report.errors.full_messages.each do |message|
-        li.text-danger = message
-
   - if params[:action] == 'new' && monthly_report.prev_month
     = button_to '先月の月報をコピー', { action: 'copy' }, params: { target_month: monthly_report.target_month }, method: 'get'
 


### PR DESCRIPTION
[月報のエラーメッセージを他に合わせる](https://github.com/hr-dash/hr-dash/issues/239)
- flashメッセージを複数表示可能にする
- 月報のエラー表示を他に合わせる（本題）
- render時は1リクエストとみなされないため`flash.now`を使用する
