### PR TITLE
Change type if messages is string

### DIFF
--- a/app/views/layouts/_flash_messages.html.slim
+++ b/app/views/layouts/_flash_messages.html.slim
@@ -1,5 +1,5 @@
 - flash.each do |type, messages|
-  - messages.each do |message|
+  - Array(messages).each do |message|
     .alert.alert-dismissible.fade.in class=(alert_class_for(type))
       button.close type="button" data-dismiss="alert"
         span aria-hidden="true" &times;


### PR DESCRIPTION
Deviseの機能でFlashに自動でメッセージが挿入される時、配列ではなく文字列でわたってしまう
