### PR TITLE
Dev/262 use same class for date

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -65,7 +65,7 @@ class User < ActiveRecord::Base
   end
 
   def report_registrable_to
-    Time.current.last_month.since(5.days).to_date
+    Time.current.since(5.days).last_month.to_date
   end
 
   def create_profile

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -65,7 +65,7 @@ class User < ActiveRecord::Base
   end
 
   def report_registrable_to
-    Time.current.last_month.since(5.days)
+    Time.current.last_month.since(5.days).to_date
   end
 
   def create_profile

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -56,7 +56,8 @@ describe User, type: :model do
   describe '#report_registrable_months' do
     let(:entry_date) { Date.new(2016, 1, 1) }
     let(:user) { create(:user, entry_date: entry_date) }
-    let(:now) { "#{today}T000000+0900" }
+    let(:now_str) { "#{today}T000000+0900" }
+    let(:now) { Time.strptime(now_str, '%Y%m%dT%H%M%S%z') }
 
     before { Timecop.freeze(now) }
     after { Timecop.return }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -56,20 +56,21 @@ describe User, type: :model do
   describe '#report_registrable_months' do
     let(:entry_date) { Date.new(2016, 1, 1) }
     let(:user) { create(:user, entry_date: entry_date) }
+    let(:now) { "#{today}T000000+0900" }
 
-    before { Timecop.freeze(today) }
+    before { Timecop.freeze(now) }
     after { Timecop.return }
     subject { user.report_registrable_months }
 
     context 'when cannot regist this month report' do
-      let(:today) { Date.new(2016, 5, 26) }
+      let(:today) { '20160525' }
       it { expect(subject.first).to eq entry_date }
       it { expect(subject.size).to eq 4 }
       it { expect(subject.last).to eq Date.new(2016, 4, 1) }
     end
 
     context 'when can regist this month report' do
-      let(:today) { Date.new(2016, 5, 27) }
+      let(:today) { '20160526' }
       it { expect(subject.first).to eq entry_date }
       it { expect(subject.size).to eq 5 }
       it { expect(subject.last).to eq Date.new(2016, 5, 1) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -63,17 +63,35 @@ describe User, type: :model do
     subject { user.report_registrable_months }
 
     context 'when cannot regist this month report' do
-      let(:today) { '20160525' }
-      it { expect(subject.first).to eq entry_date }
-      it { expect(subject.size).to eq 4 }
-      it { expect(subject.last).to eq Date.new(2016, 4, 1) }
+      context 'short month' do
+        let(:today) { '20160425' }
+        it { expect(subject.first).to eq entry_date }
+        it { expect(subject.size).to eq 3 }
+        it { expect(subject.last).to eq Date.new(2016, 3, 1) }
+      end
+
+      context 'long month' do
+        let(:today) { '20160526' }
+        it { expect(subject.first).to eq entry_date }
+        it { expect(subject.size).to eq 4 }
+        it { expect(subject.last).to eq Date.new(2016, 4, 1) }
+      end
     end
 
     context 'when can regist this month report' do
-      let(:today) { '20160526' }
-      it { expect(subject.first).to eq entry_date }
-      it { expect(subject.size).to eq 5 }
-      it { expect(subject.last).to eq Date.new(2016, 5, 1) }
+      context 'short month' do
+        let(:today) { '20160426' }
+        it { expect(subject.first).to eq entry_date }
+        it { expect(subject.size).to eq 4 }
+        it { expect(subject.last).to eq Date.new(2016, 4, 1) }
+      end
+
+      context 'long month' do
+        let(:today) { '20160527' }
+        it { expect(subject.first).to eq entry_date }
+        it { expect(subject.size).to eq 5 }
+        it { expect(subject.last).to eq Date.new(2016, 5, 1) }
+      end
     end
   end
 end


### PR DESCRIPTION
[月報の対象月において、登録時に最新月を選択できないことがある](https://github.com/hr-dash/hr-dash/issues/262)

なかなかややこしかったですが、 **「5日後の1ヶ月前の日が属する月」** まで登録できると考えればようやく治まった気がします笑
1ヶ月前に戻るのは`last_month`で

| 今日 | 5日後 | 5日後の1ヶ月前 | 登録可能月 |
| :-- | :-- | :-- | :-- |
| 4/25 | 4/30 | 3/30 | 3月 |
| 4/26 | 5/1 | 4/1 | 4月 |
| 5/26 | 5/31 | 4/30 | 4月 |
| 5/27 | 6/1 | 5/1 | 5月 |
