### PR TITLE
Dev/292 tag regexp

### DIFF
--- a/app/controllers/monthly_reports_controller.rb
+++ b/app/controllers/monthly_reports_controller.rb
@@ -79,9 +79,11 @@ class MonthlyReportsController < ApplicationController
   end
 
   def monthly_report_tags
-    tags = params[:monthly_report][:monthly_report_tags].try!(:split, ',').try!(:map) do |tag|
-      Tag.find_or_create_by(name: tag.strip)
-    end
+    tags = params[:monthly_report][:monthly_report_tags].try!(:split, ',').try!(:map) do |name|
+      tag = Tag.find_or_initialize_by(name: name.strip)
+      tag.save ? tag : nil # 許容できないタグは無視
+    end.try!(:compact)
+
     tags || []
   end
 

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -10,8 +10,10 @@
 #
 
 class Tag < ActiveRecord::Base
+  VALID_NAME_REGEX = /\A(?:[a-zA-Z0-9_\.\+\#\'-]|\p{Blank}|\p{Hiragana}|\p{Katakana}|[ー－]|[一-龠々])+\z/
+
   validates :status, presence: true
-  validates :name, length: { maximum: 32 }, presence: true
+  validates :name, length: { maximum: 32 }, presence: true, format: { with: VALID_NAME_REGEX }
 
   enum status: { unfixed: 0, fixed: 1 }
 end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -17,5 +17,33 @@ describe Tag, type: :model do
     it { is_expected.to validate_presence_of(:status) }
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_length_of(:name).is_at_most(32) }
+
+    describe 'VALID_NAME_REGEX' do
+      context 'allowed chars' do
+        allowed_chars = [
+          'a', 'A', '0',
+          '_', '.', '+',
+          '#', "'", '-',
+          'spa ce', 'あ', 'ア', '漢'
+        ]
+
+        allowed_chars.each do |c|
+          it { is_expected.to allow_value(c).for(:name) }
+        end
+      end
+
+      context 'not allowed chars' do
+        not_allowed_chars = [
+          '!', '"', '$', '%', '&',
+          '(', ')', '=', '~', '?',
+          '|', '@', '`', '{', '}',
+          '*', ';', ',', ':', '/'
+        ]
+
+        not_allowed_chars.each do |c|
+          it { is_expected.not_to allow_value(c).for(:name) }
+        end
+      end
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -98,7 +98,7 @@ describe User, type: :model do
 
   describe '#active_for_authentication?' do
     let(:user) { create(:user, deleted_at: deleted_at) }
-    let(:today) { Date.today }
+    let(:today) { Time.current.to_date }
     subject { user.active_for_authentication? }
 
     context 'active' do


### PR DESCRIPTION
[タグ登録時に特定文字列で消せないタグとして登録される](https://github.com/hr-dash/hr-dash/issues/292)

登録可能な文字をホワイトリストにして対応。リストは以下
- 半角英数字
- ひらがな・カタカナ・漢字
- 空白
- `+` ex. `C++`
- `#` ex. `C#`
- `-` ex. `Objective-C`
- `.` ex. `Node.js`
- `'` ex. アポストロフィー

※ `presence: true` してるので空白のみは不可
