### PR TITLE
Dev/295 add password change link

### DIFF
--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -61,6 +61,10 @@ ActiveAdmin.register User do
     f.actions
   end
 
+  action_item :change_password, only: [:edit, :show] do
+    link_to 'PW変更', edit_password_admin_user_path(user)
+  end
+
   member_action :edit_password, method: :get do
     @user = resource
   end

--- a/spec/features/admin/user_spec.rb
+++ b/spec/features/admin/user_spec.rb
@@ -14,6 +14,7 @@ describe 'Admin::User', type: :feature do
     before { visit admin_user_path(user) }
     it { expect(page_title).to have_content(user.name) }
     it { expect(page).to have_content(user.group.name) }
+    it { expect(page).to have_content('PW変更') }
   end
 
   describe '#create' do


### PR DESCRIPTION
[管理画面のユーザ詳細画面からパスワード変更画面に遷移できない](https://github.com/hr-dash/hr-dash/issues/295)

ユーザー詳細画面、編集画面からもパスワード変更画面に飛べるようリンクを追加
