### PR TITLE
Dev/294 hide deleted group

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,5 +1,5 @@
 class GroupsController < ApplicationController
   def index
-    @groups = Group.includes(:users).all.order(:id)
+    @groups = Group.includes(:users).active.order(:id)
   end
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -16,4 +16,6 @@ class Group < ActiveRecord::Base
 
   validates :name, presence: true
   validates :email, presence: true, format: { with: /\A[^@]+@[^@]+\z/ }
+
+  scope :active, -> { where('deleted_at IS NULL OR deleted_at > ?', Time.current) }
 end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -19,4 +19,24 @@ describe Group, type: :model do
   describe 'Validations' do
     it { is_expected.to validate_presence_of(:name) }
   end
+
+  describe '.active' do
+    let!(:group) { create(:group, deleted_at: deleted_at) }
+    subject { described_class.active.present? }
+
+    context 'when deleted_at is nil' do
+      let(:deleted_at) { nil }
+      it { is_expected.to eq true }
+    end
+
+    context 'when deleted_at is future' do
+      let(:deleted_at) { Time.current.tomorrow }
+      it { is_expected.to eq true }
+    end
+
+    context 'when deleted_at is past' do
+      let(:deleted_at) { Time.current.yesterday }
+      it { is_expected.to eq false }
+    end
+  end
 end


### PR DESCRIPTION
[deleted_atに値があるグループが一覧に表示されないようにする](https://github.com/hr-dash/hr-dash/issues/294)

deleted_atが無いか未来日付の場合に `active` とするscopeを追加
