### PR TITLE
Dev/293 drop monthly report status

### DIFF
--- a/app/admin/monthly_report.rb
+++ b/app/admin/monthly_report.rb
@@ -17,7 +17,6 @@ ActiveAdmin.register MonthlyReport do
     column :target_month do |r|
       div { r.target_month.strftime('%Y年%m月') }
     end
-    column :status
     column :shipped_at
     column :project_summary
     actions
@@ -25,7 +24,6 @@ ActiveAdmin.register MonthlyReport do
 
   filter :user
   filter :target_month
-  filter :status, as: :select, collection: MonthlyReport.statuses
   filter :shipped_at
   filter :project_summary
   filter :monthly_report_tags
@@ -36,7 +34,6 @@ ActiveAdmin.register MonthlyReport do
       row :id
       row :user
       row :target_month
-      row :status
       row :shipped_at
       row :project_summary
       row :business_content
@@ -61,7 +58,6 @@ ActiveAdmin.register MonthlyReport do
     f.inputs 'MonthlyReport Details' do
       f.input :user
       f.input :target_month, as: :datepicker
-      f.input :status, as: :select, collection: MonthlyReport.statuses.keys
       f.input :shipped_at, as: :datepicker
       f.input :project_summary
       f.input :business_content

--- a/app/controllers/monthly_reports_controller.rb
+++ b/app/controllers/monthly_reports_controller.rb
@@ -65,7 +65,7 @@ class MonthlyReportsController < ApplicationController
   end
 
   def assign_relational_params(report)
-    report.status = params[:wip] ? :wip : :shipped
+    report.shipped! unless params[:wip]
     report.monthly_working_processes = working_processes(report)
     report.tags = monthly_report_tags
   end

--- a/app/controllers/monthly_reports_controller.rb
+++ b/app/controllers/monthly_reports_controller.rb
@@ -123,7 +123,7 @@ class MonthlyReportsController < ApplicationController
   end
 
   def monthly_report_notify(shipped_at_was)
-    return if @monthly_report.wip? || shipped_at_was.present?
+    return if shipped_at_was.present?
     Notify.monthly_report_registration(@monthly_report.user.id, @monthly_report.id).deliver_now
   end
 end

--- a/app/models/monthly_report.rb
+++ b/app/models/monthly_report.rb
@@ -5,7 +5,6 @@
 #  id               :integer          not null, primary key
 #  user_id          :integer          not null
 #  target_month     :date             not null
-#  status           :integer          not null
 #  shipped_at       :datetime
 #  project_summary  :text
 #  business_content :text
@@ -44,8 +43,6 @@ class MonthlyReport < ActiveRecord::Base
 
   scope :year, ->(year) { where(target_month: (Time.zone.local(year))..(Time.zone.local(year).end_of_year)) }
   scope :released, -> { where.not(shipped_at: nil) }
-
-  enum status: { wip: 0, shipped: 1 }
 
   before_save :log_shipped_at
 

--- a/app/models/monthly_report.rb
+++ b/app/models/monthly_report.rb
@@ -44,8 +44,6 @@ class MonthlyReport < ActiveRecord::Base
   scope :year, ->(year) { where(target_month: (Time.zone.local(year))..(Time.zone.local(year).end_of_year)) }
   scope :released, -> { where.not(shipped_at: nil) }
 
-  before_save :log_shipped_at
-
   def self.of_latest_month_registered_by(user)
     user.monthly_reports.find_by(target_month: user.report_registrable_to.beginning_of_month)
   end
@@ -80,6 +78,14 @@ class MonthlyReport < ActiveRecord::Base
     self
   end
 
+  def shipped!
+    self.shipped_at ||= Time.current
+  end
+
+  def shipped?
+    shipped_at.present?
+  end
+
   private
 
   def target_month_registrable_term
@@ -99,10 +105,5 @@ class MonthlyReport < ActiveRecord::Base
     return if target_month.blank? || user.blank?
     return unless self.class.find_by(user: user, target_month: target_month)
     errors.add :target_month, 'report already registered'
-  end
-
-  def log_shipped_at
-    return if status == 'wip'
-    self.shipped_at ||= Time.current
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,6 +21,9 @@
 #  last_sign_in_at        :datetime
 #  current_sign_in_ip     :inet
 #  last_sign_in_ip        :inet
+#  failed_attempts        :integer          default(0), not null
+#  unlock_token           :string
+#  locked_at              :datetime
 #  gender                 :integer          default(0), not null
 #
 

--- a/app/views/monthly_reports/_form.html.slim
+++ b/app/views/monthly_reports/_form.html.slim
@@ -49,5 +49,8 @@
       .col-xs-9
         == render 'layouts/markdown_editor', attr: :next_month_goals, form: f, placeholder: placeholders[:next_month_goals]
     = f.hidden_field :target_month
-    = f.button 'Save as WIP（下書き保存）', name: :wip, class: 'btn btn-lg btn-info btn-block'
-    = f.button 'Ship（保存して公開）', class: 'btn btn-lg btn-success btn-block'
+    - if monthly_report.shipped?
+      = f.button 'Update（月報を更新）', class: 'btn btn-lg btn-success btn-block'
+    - else
+      = f.button 'Save as WIP（下書き保存）', name: :wip, class: 'btn btn-lg btn-info btn-block'
+      = f.button 'Ship（保存して公開）', class: 'btn btn-lg btn-success btn-block'

--- a/app/views/monthly_reports/show.html.slim
+++ b/app/views/monthly_reports/show.html.slim
@@ -11,7 +11,7 @@
           - if @monthly_report.shipped?
             span.label.label-success.monthly-report-status 登録済
           -else
-            span.label.label-info.monthly-report-status 下書き中
+            span.label.label-info.monthly-report-status 下書き
           = "#{@monthly_report.target_month.strftime("%Y年%m月")}の月報"
         .col-xs-2
           - if @monthly_report.next_month

--- a/config/locales/activerecord.ja.yml
+++ b/config/locales/activerecord.ja.yml
@@ -30,7 +30,6 @@ ja:
         next_month_goals: 来月の目標
         target_month: 対象月
         shipped_at: 公開日
-        status: ステータス
       monthly_report_comment:
         comment: コメント
       monthly_working_process:

--- a/db/migrate/20150825121144_create_monthly_reports.rb
+++ b/db/migrate/20150825121144_create_monthly_reports.rb
@@ -3,7 +3,6 @@ class CreateMonthlyReports < ActiveRecord::Migration
     create_table :monthly_reports do |t|
       t.integer :user_id,       null: false
       t.datetime :target_month, null: false, index: true
-      t.integer :status,        null: false
       t.datetime :shipped_at
       t.text :project_summary
       t.text :business_content

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -83,7 +83,6 @@ ActiveRecord::Schema.define(version: 20160428131101) do
   create_table "monthly_reports", force: :cascade do |t|
     t.integer  "user_id",          null: false
     t.date     "target_month",     null: false
-    t.integer  "status",           null: false
     t.datetime "shipped_at"
     t.text     "project_summary"
     t.text     "business_content"

--- a/spec/factories/monthly_report.rb
+++ b/spec/factories/monthly_report.rb
@@ -7,8 +7,12 @@ FactoryGirl.define do
     looking_back { Faker::Lorem.paragraph }
     next_month_goals { Faker::Lorem.paragraph }
 
+    trait :wip do
+      shipped_at { nil }
+    end
+
     trait :shipped do
-      shippted_at { Time.current }
+      shipped_at { Time.current }
     end
 
     trait :with_comments do

--- a/spec/factories/monthly_report.rb
+++ b/spec/factories/monthly_report.rb
@@ -1,19 +1,14 @@
 FactoryGirl.define do
   factory :monthly_report do
     association :user
-    status { MonthlyReport.statuses[:wip] }
     target_month { Faker::Date.between(6.months.ago, 1.months.ago).beginning_of_month }
     project_summary { Faker::Lorem.paragraph }
     business_content { Faker::Lorem.paragraph }
     looking_back { Faker::Lorem.paragraph }
     next_month_goals { Faker::Lorem.paragraph }
 
-    trait :wip do
-      status { MonthlyReport.statuses[:wip] }
-    end
-
     trait :shipped do
-      status { MonthlyReport.statuses[:shipped] }
+      shippted_at { Time.current }
     end
 
     trait :with_comments do

--- a/spec/features/admin/monthly_report_spec.rb
+++ b/spec/features/admin/monthly_report_spec.rb
@@ -8,7 +8,7 @@ describe 'Admin::MonthlyReport', type: :feature do
     before { visit admin_monthly_reports_path }
     it { expect(page_title).to have_content('月報') }
     it { expect(page).to have_content(user.name) }
-    it { expect(page).to have_content(report.status) }
+    it { expect(page).to have_content(report.shipped_at) }
     it { expect(page).not_to have_css('.delete_link') }
   end
 

--- a/spec/features/monthly_report_spec.rb
+++ b/spec/features/monthly_report_spec.rb
@@ -3,8 +3,8 @@ describe MonthlyReportsController, type: :feature do
 
   describe '#index GET /monthly_reports' do
     describe 'sort by shipped_at desc' do
-      let!(:today) { create(:monthly_report, shipped_at: Date.today) }
-      let!(:yesterday) { create(:monthly_report, shipped_at: Date.yesterday) }
+      let!(:today) { create(:monthly_report, :with_tags, :with_working_processes, shipped_at: Date.today) }
+      let!(:yesterday) { create(:monthly_report, :with_tags, :with_working_processes, shipped_at: Date.yesterday) }
       let(:first_report) { find('#report_index').first('a') }
 
       before { visit monthly_reports_path }

--- a/spec/models/monthly_report_spec.rb
+++ b/spec/models/monthly_report_spec.rb
@@ -101,20 +101,6 @@ RSpec.describe MonthlyReport, type: :model do
     end
   end
 
-  describe 'Callbacks' do
-    describe '#log_shipped_at' do
-      context 'wip' do
-        let(:report) { create(:monthly_report) }
-        it { expect(report.shipped_at).to be nil }
-      end
-
-      context 'shipped' do
-        let(:report) { create(:shipped_montly_report) }
-        it { expect(report.shipped_at).not_to be nil }
-      end
-    end
-  end
-
   describe '.of_latest_month_registered_by' do
     let(:user) { create(:user) }
 
@@ -162,6 +148,47 @@ RSpec.describe MonthlyReport, type: :model do
     context 'exist last month report' do
       before { create(:shipped_montly_report, target_month: report.target_month.last_month, user: user) }
       it { expect { subject }.not_to raise_error }
+    end
+  end
+
+  describe '#shipped!' do
+    let(:report) { build(:monthly_report) }
+
+    context 'wip' do
+      it { expect(report.shipped_at).to be nil }
+    end
+
+    context 'shipped' do
+      before { report.shipped! }
+
+      context 'at first time' do
+        it { expect(report.shipped_at).not_to be nil }
+      end
+
+      context 'after second time' do
+        let(:tomorrow) { Time.current.tomorrow }
+
+        before do
+          Timecop.freeze(tomorrow) do
+            report.shipped!
+          end
+        end
+
+        it { expect(report.shipped_at).not_to be nil }
+        it { expect(report.shipped_at).not_to eq tomorrow }
+      end
+    end
+  end
+
+  describe '#shipped?' do
+    context 'wip' do
+      let(:report) { build(:monthly_report, :wip) }
+      it { expect(report).not_to be_shipped }
+    end
+
+    context 'shipped' do
+      let(:report) { build(:monthly_report, :shipped) }
+      it { expect(report).to be_shipped }
     end
   end
 end

--- a/spec/models/monthly_report_spec.rb
+++ b/spec/models/monthly_report_spec.rb
@@ -5,7 +5,6 @@
 #  id               :integer          not null, primary key
 #  user_id          :integer          not null
 #  target_month     :date             not null
-#  status           :integer          not null
 #  shipped_at       :datetime
 #  project_summary  :text
 #  business_content :text
@@ -26,13 +25,13 @@ RSpec.describe MonthlyReport, type: :model do
       it { is_expected.to validate_length_of(:next_month_goals).is_at_most(5000) }
     end
 
-    context 'when status is wip' do
+    context 'when report is wip' do
       subject { build(:monthly_report) }
       it { is_expected.to be_valid }
       it_behaves_like 'common validations'
     end
 
-    context 'when status is shipped' do
+    context 'when report is shipped' do
       subject { build(:shipped_montly_report) }
       it { is_expected.to be_valid }
       it_behaves_like 'common validations'

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -21,6 +21,9 @@
 #  last_sign_in_at        :datetime
 #  current_sign_in_ip     :inet
 #  last_sign_in_ip        :inet
+#  failed_attempts        :integer          default(0), not null
+#  unlock_token           :string
+#  locked_at              :datetime
 #  gender                 :integer          default(0), not null
 #
 

--- a/spec/requests/monthly_report_spec.rb
+++ b/spec/requests/monthly_report_spec.rb
@@ -219,7 +219,8 @@ describe MonthlyReportsController, type: :request do
     let(:report_params) { attributes_for(:monthly_report, :shipped) }
     let(:tag_params) { 'Ruby,Rails' }
     let(:process_params) { [build(:monthly_working_process).process] }
-    let(:user_report) { MonthlyReport.find_by(report_params, user: report.user) }
+    let(:find_params) { report_params.reject { |k, _| k == :shipped_at } }
+    let(:user_report) { MonthlyReport.find_by(find_params, user: report.user) }
     let(:patch_params) do
       {
         monthly_report: report_params.merge(monthly_report_tags: tag_params),


### PR DESCRIPTION
[[月報登録] 登録済みの月報の編集で下書き保存を行うと予期しない表示になる](https://github.com/hr-dash/hr-dash/issues/293)
- `MonthlyReport#status` は不要なので削除
- `shipped_at` の有無で下書き／公開済を判断
