### PR TITLE
Dev/generate secure password in specs

### DIFF
--- a/spec/features/admin/user_spec.rb
+++ b/spec/features/admin/user_spec.rb
@@ -36,8 +36,7 @@ describe 'Admin::User', type: :feature do
 
   describe '#update_password' do
     let(:other_user) { create(:user) }
-    let(:required_chars) { 'aA1' } # 大文字小文字数字1字以上
-    let(:new_password) { Faker::Internet.password + required_chars }
+    let(:new_password) { generate_random_password }
     before do
       visit edit_password_admin_user_path(other_user)
       fill_in 'パスワード', with: new_password

--- a/spec/features/password_reset_spec.rb
+++ b/spec/features/password_reset_spec.rb
@@ -27,7 +27,7 @@ describe PasswordResetsController, type: :feature do
   describe '#update' do
     let(:user) { create(:user) }
     let!(:original_token) { user.send_reset_password_instructions }
-    let(:new_password) { Faker::Internet.password }
+    let(:new_password) { generate_random_password }
     let(:password_confirmation) { new_password }
     let(:token) { original_token }
 
@@ -50,7 +50,7 @@ describe PasswordResetsController, type: :feature do
     end
 
     context 'differ between new_password and its confirmation' do
-      let(:password_confirmation) { Faker::Internet.password }
+      let(:password_confirmation) { generate_random_password }
       it { expect(user.reload.reset_password_token).not_to be nil }
       it { expect(page.body).to have_content('パスワードの入力が一致しません') }
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -76,5 +76,6 @@ RSpec.configure do |config|
   config.include RequestHelpers, type: :request
   config.include RequestHelpers, type: :feature
 
+  config.include Helpers
   config.include Capybara::DSL
 end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -1,0 +1,10 @@
+module Helpers
+  def generate_random_password
+    required_chars = ['A'..'Z', 'a'..'z', '0'..'9'].map do |range|
+      chars = range.to_a
+      chars[rand(chars.size)]
+    end
+
+    Faker::Internet.password + required_chars.join
+  end
+end


### PR DESCRIPTION
# 概要

[パスワードポリシーの変更](https://github.com/hr-dash/hr-dash/pull/326) に伴い、spec内でPassword生成してる箇所もポリシーに従った生成を行なうよう修正

[ポリシーの規則に反した生成をした時の失敗テスト（サンプル）](https://circleci.com/gh/hr-dash/hr-dash/584?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link)
