### PR TITLE
Dev/325 loginid encryption

### DIFF
--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -26,7 +26,6 @@ ActiveAdmin.register User do
     column :group
     column :gender, :gender_i18n
     column :employee_code
-    column :email
     column :entry_date
     column :beginner_flg
     column :deleted_at

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -4,7 +4,7 @@ class PasswordResetsController < Devise::PasswordsController
   def new; end
 
   def create
-    user = User.find_by(email: params[:email])
+    user = User.find_for_database_authentication(email: params[:email])
 
     if user.try!(:active_for_authentication?)
       user.send_reset_password_instructions

--- a/app/models/concerns/encryptor.rb
+++ b/app/models/concerns/encryptor.rb
@@ -36,11 +36,7 @@ module Encryptor
 
     def define_getter(column)
       define_method(column) do
-        begin
-          self.class.decrypt(self["encrypted_#{column}"])
-        rescue ActiveSupport::MessageVerifier::InvalidSignature
-          self["encrypted_#{column}"]
-        end
+        self.class.decrypt(self["encrypted_#{column}"])
       end
     end
 

--- a/app/models/concerns/encryptor.rb
+++ b/app/models/concerns/encryptor.rb
@@ -3,6 +3,7 @@ module Encryptor
 
   CIPHER = ENV['ENCRYPTOR_CIPHER']
   PASS = ENV['ENCRYPTOR_PASS']
+  SALT = ENV['ENCRYPTOR_SALT']
 
   module ClassMethods
     def encrypt(data)
@@ -10,7 +11,7 @@ module Encryptor
 
       cipher = OpenSSL::Cipher::Cipher.new(CIPHER)
       cipher.encrypt
-      cipher.pkcs5_keyivgen(PASS)
+      cipher.pkcs5_keyivgen(PASS, SALT)
       Base64.strict_encode64(cipher.update(data) + cipher.final)
     end
 
@@ -19,7 +20,7 @@ module Encryptor
 
       cipher = OpenSSL::Cipher::Cipher.new(CIPHER)
       cipher.decrypt
-      cipher.pkcs5_keyivgen(PASS)
+      cipher.pkcs5_keyivgen(PASS, SALT)
       cipher.update(Base64.decode64(data)) + cipher.final
     end
 

--- a/app/models/concerns/encryptor.rb
+++ b/app/models/concerns/encryptor.rb
@@ -1,0 +1,44 @@
+module Encryptor
+  extend ActiveSupport::Concern
+
+  CIPHER = ENV["ENCRYPTOR_CIPHER"]
+  PASS = ENV["ENCRYPTOR_PASS"]
+
+  module ClassMethods
+    def encrypt(data)
+      cipher = OpenSSL::Cipher::Cipher.new(CIPHER)
+      cipher.encrypt
+      cipher.pkcs5_keyivgen(PASS)
+      Base64.strict_encode64(cipher.update(data) + cipher.final)
+    end
+
+    def decrypt(data)
+      return unless data
+
+      cipher = OpenSSL::Cipher::Cipher.new(CIPHER)
+      cipher.decrypt
+      cipher.pkcs5_keyivgen(PASS)
+      cipher.update(Base64.decode64(data)) + cipher.final
+    end
+
+    def encrypted_columns(*columns)
+      columns.each do |column|
+        define_method(column) do
+          begin
+            self.class.decrypt(self["encrypted_#{column}"])
+          rescue ActiveSupport::MessageVerifier::InvalidSignature
+            self["encrypted_#{column}"]
+          end
+        end
+
+        define_method("#{column}=") do |value|
+          self["encrypted_#{column}"] = self.class.encrypt(value)
+        end
+
+        define_method("#{column}_changed?") do
+          self["encrypted_#{column}_changed?"]
+        end
+      end
+    end
+  end
+end

--- a/app/models/concerns/encryptor.rb
+++ b/app/models/concerns/encryptor.rb
@@ -6,6 +6,8 @@ module Encryptor
 
   module ClassMethods
     def encrypt(data)
+      return unless data
+
       cipher = OpenSSL::Cipher::Cipher.new(CIPHER)
       cipher.encrypt
       cipher.pkcs5_keyivgen(PASS)

--- a/app/models/concerns/encryptor.rb
+++ b/app/models/concerns/encryptor.rb
@@ -1,8 +1,8 @@
 module Encryptor
   extend ActiveSupport::Concern
 
-  CIPHER = ENV["ENCRYPTOR_CIPHER"]
-  PASS = ENV["ENCRYPTOR_PASS"]
+  CIPHER = ENV['ENCRYPTOR_CIPHER']
+  PASS = ENV['ENCRYPTOR_PASS']
 
   module ClassMethods
     def encrypt(data)
@@ -25,21 +25,28 @@ module Encryptor
 
     def encrypted_columns(*columns)
       columns.each do |column|
-        define_method(column) do
-          begin
-            self.class.decrypt(self["encrypted_#{column}"])
-          rescue ActiveSupport::MessageVerifier::InvalidSignature
-            self["encrypted_#{column}"]
-          end
-        end
-
-        define_method("#{column}=") do |value|
-          self["encrypted_#{column}"] = self.class.encrypt(value)
-        end
+        define_getter(column)
+        define_setter(column)
 
         define_method("#{column}_changed?") do
           self["encrypted_#{column}_changed?"]
         end
+      end
+    end
+
+    def define_getter(column)
+      define_method(column) do
+        begin
+          self.class.decrypt(self["encrypted_#{column}"])
+        rescue ActiveSupport::MessageVerifier::InvalidSignature
+          self["encrypted_#{column}"]
+        end
+      end
+    end
+
+    def define_setter(column)
+      define_method("#{column}=") do |value|
+        self["encrypted_#{column}"] = self.class.encrypt(value)
       end
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,7 @@
 #  name                   :string
 #  group_id               :integer
 #  employee_code          :string
-#  email                  :string
+#  encrypted_email        :string           not null
 #  entry_date             :date
 #  beginner_flg           :boolean
 #  deleted_at             :datetime

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,6 +42,7 @@ class User < ActiveRecord::Base
 
   validates :name, length: { maximum: 32 }, presence: true
   validates :employee_code, presence: true, uniqueness: true
+  validates :encrypted_email, presence: true
   validates :entry_date, presence: true
   validates :beginner_flg, inclusion: { in: [true, false] }
   validates :gender, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,6 +21,9 @@
 #  last_sign_in_at        :datetime
 #  current_sign_in_ip     :inet
 #  last_sign_in_ip        :inet
+#  failed_attempts        :integer          default(0), not null
+#  unlock_token           :string
+#  locked_at              :datetime
 #  gender                 :integer          default(0), not null
 #
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -57,7 +57,7 @@ class User < ActiveRecord::Base
          :recoverable, :rememberable, :trackable, :validatable, :lockable
 
   def self.find_for_database_authentication(warden_conditions)
-    where(encrypted_email: encrypt(warden_conditions[:email])).first
+    find_by(encrypted_email: encrypt(warden_conditions[:email]))
   end
 
   def report_registrable_months

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,6 +28,9 @@
 #
 
 class User < ActiveRecord::Base
+  include Encryptor
+  encrypted_columns :email
+
   PASSWORD_REGEX = %r|\A(?=.*?[a-z])(?=.*?[A-Z])(?=.*?\d)[a-zA-Z\d#$%&@'()\/\*\+\.=-]{8,72}+\z|
 
   has_one :user_profile, dependent: :destroy
@@ -52,6 +55,10 @@ class User < ActiveRecord::Base
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable,
          :recoverable, :rememberable, :trackable, :validatable, :lockable
+
+  def self.find_for_database_authentication(warden_conditions)
+    where(encrypted_email: encrypt(warden_conditions[:email])).first
+  end
 
   def report_registrable_months
     months = []

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,4 +1,4 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [:password]
+Rails.application.config.filter_parameters += [:email, :password]

--- a/db/migrate/20150910122142_create_users.rb
+++ b/db/migrate/20150910122142_create_users.rb
@@ -4,7 +4,7 @@ class CreateUsers < ActiveRecord::Migration
       t.string :name
       t.belongs_to :group, index: true
       t.string :employee_code
-      t.string :email
+      t.string :encrypted_email, null: false
       t.date :entry_date
       t.boolean :beginner_flg
       t.datetime :deleted_at

--- a/db/migrate/20150924122432_add_devise_to_users.rb
+++ b/db/migrate/20150924122432_add_devise_to_users.rb
@@ -34,7 +34,6 @@ class AddDeviseToUsers < ActiveRecord::Migration
       # t.timestamps null: false
     end
 
-    add_index :users, :email,                unique: true
     add_index :users, :reset_password_token, unique: true
     # add_index :users, :confirmation_token,   unique: true
     # add_index :users, :unlock_token,         unique: true

--- a/db/migrate/20150924122432_add_devise_to_users.rb
+++ b/db/migrate/20150924122432_add_devise_to_users.rb
@@ -34,6 +34,7 @@ class AddDeviseToUsers < ActiveRecord::Migration
       # t.timestamps null: false
     end
 
+    add_index :users, :encrypted_email,      unique: true
     add_index :users, :reset_password_token, unique: true
     # add_index :users, :confirmation_token,   unique: true
     # add_index :users, :unlock_token,         unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -158,6 +158,7 @@ ActiveRecord::Schema.define(version: 20160428131101) do
     t.integer  "gender",                 default: 0,  null: false
   end
 
+  add_index "users", ["encrypted_email"], name: "index_users_on_encrypted_email", unique: true, using: :btree
   add_index "users", ["group_id"], name: "index_users_on_group_id", using: :btree
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -137,7 +137,7 @@ ActiveRecord::Schema.define(version: 20160428131101) do
     t.string   "name"
     t.integer  "group_id"
     t.string   "employee_code"
-    t.string   "email"
+    t.string   "encrypted_email",                     null: false
     t.date     "entry_date"
     t.boolean  "beginner_flg"
     t.datetime "deleted_at"
@@ -158,7 +158,6 @@ ActiveRecord::Schema.define(version: 20160428131101) do
     t.integer  "gender",                 default: 0,  null: false
   end
 
-  add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
   add_index "users", ["group_id"], name: "index_users_on_group_id", using: :btree
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
 

--- a/spec/models/concerns/encryptor_spec.rb
+++ b/spec/models/concerns/encryptor_spec.rb
@@ -1,0 +1,41 @@
+describe Encryptor, type: :model do
+  class Sample
+    include Encryptor
+    encrypted_columns :email
+
+    attr_accessor :encrypted_email
+    # ref: http://api.rubyonrails.org/classes/ActiveRecord/AttributeMethods.html#method-i-5B-5D
+    def [](attr_name)
+      send(attr_name)
+    end
+
+    def []=(attr_name, value)
+      send("#{attr_name}=", value)
+    end
+  end
+
+  context 'included' do
+    let(:sample) { Sample.new }
+
+    describe 'define methods for encryption' do
+      it { expect(Sample).to respond_to(:encrypt) }
+      it { expect(Sample).to respond_to(:decrypt) }
+      it { expect(Sample).to respond_to(:encrypted_columns) }
+
+      it { expect(sample).to respond_to(:email) }
+      it { expect(sample).to respond_to(:email=) }
+      it { expect(sample).to respond_to(:email_changed?) }
+    end
+
+    describe 'encryption' do
+      let(:sample_email) { Faker::Internet.email }
+      let(:encrypted) { Sample.encrypt(sample_email) }
+
+      before { sample.email = sample_email }
+
+      it { expect(sample.encrypted_email).to eq encrypted }
+      it { expect(sample.email).to eq sample_email }
+      it { expect(sample.email).not_to eq encrypted }
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -21,6 +21,9 @@
 #  last_sign_in_at        :datetime
 #  current_sign_in_ip     :inet
 #  last_sign_in_ip        :inet
+#  failed_attempts        :integer          default(0), not null
+#  unlock_token           :string
+#  locked_at              :datetime
 #  gender                 :integer          default(0), not null
 #
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -45,6 +45,7 @@ describe User, type: :model do
     it { is_expected.to validate_length_of(:name).is_at_most(32) }
     it { is_expected.to validate_presence_of(:employee_code) }
     it { is_expected.to validate_uniqueness_of(:employee_code) }
+    it { is_expected.to validate_presence_of(:encrypted_email) }
     it { is_expected.to validate_presence_of(:entry_date) }
     it { is_expected.to validate_presence_of(:gender) }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -6,7 +6,7 @@
 #  name                   :string
 #  group_id               :integer
 #  employee_code          :string
-#  email                  :string
+#  encrypted_email        :string           not null
 #  entry_date             :date
 #  beginner_flg           :boolean
 #  deleted_at             :datetime
@@ -45,7 +45,6 @@ describe User, type: :model do
     it { is_expected.to validate_length_of(:name).is_at_most(32) }
     it { is_expected.to validate_presence_of(:employee_code) }
     it { is_expected.to validate_uniqueness_of(:employee_code) }
-    it { is_expected.to validate_presence_of(:email) }
     it { is_expected.to validate_presence_of(:entry_date) }
     it { is_expected.to validate_presence_of(:gender) }
 


### PR DESCRIPTION
# 概要

セキュリティ強化の為、ログインEmailについてもDB格納時に暗号化する。
他に暗号化対応が必要なカラムが出てくる可能性もあるため、ロジックは別で切り出しておく。
# 対応Issue

[ログインEmailの暗号化](https://github.com/hr-dash/hr-dash/issues/325)
# 確認方法

`.env` に以下の2設定が必要
- `ENCRYPTOR_CIPHER`
- `ENCRYPTOR_PASS`

`rake db:migrate:reset` `rake db:seed` 等でユーザーを作り直し、
- 暗号化された `encrypted_email` カラムがある
- 暗号化されてない `email` カラムがない

ことを確認すれば良い。
また、ログに出力される項目として `email` も `[FILTERED]` と隠されていることも確認する
# 参考URL
- [Ruby スクリプトでデータを暗号化する方法](http://webos-goodies.jp/archives/encryption_in_ruby.html)
- [暗号化されたCSVファイルを復号化する](http://qiita.com/kuwa72/items/782bbcc08eae27e3625d)
