### PR TITLE
Create ActiveAdminActionLog on change user password

### DIFF
--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -73,6 +73,13 @@ ActiveAdmin.register User do
     @user.assign_attributes(password_params)
 
     if @user.save
+      ActiveAdminActionLog.create do |log|
+        log.user = current_user
+        log.resource = resource
+        log.path = resource_path
+        log.action = action_name
+      end
+
       redirect_to action: :index
     else
       flash[:error] = @user.errors.full_messages


### PR DESCRIPTION
# 概要

[ログ] パスワードのupdateがログに残るようにする
- 管理画面でパスワード変更時にActiveAdminActionLogに記録を残す
- 変更したパスワードの中身は表示せず、いつ、誰が、誰のパスワードを変更したかがわかれば良い
- そのためchangesは不要
# 再現・確認手順

管理画面でパスワードを変更し、Log画面に記録が残ることを確認
# 対応Issue（任意）

https://github.com/hr-dash/hr-dash/issues/305
# ToDo
- [x] ラベル付け
- [x] Assigneesで自分を選択
