### PR TITLE
Fix seeds of user_roles

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -29,5 +29,5 @@ else
                      employee_code: 'x',
                      entry_date: Date.today,
                      beginner_flg: true)
-  UserRole.create(user: user, admin: true)
+  UserRole.create(user: user, role: 0)
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -29,5 +29,5 @@ else
                      employee_code: 'x',
                      entry_date: Date.today,
                      beginner_flg: true)
-  UserRole.create(user: user, role: 0)
+  UserRole.create(user: user, role: :admin)
 end


### PR DESCRIPTION
# 概要
- production用の初期データを流すのに失敗するため、修正
- 原因
  - `db/seeds.rb` で UserRoleが過去の構成でcreateされるようになっていた  
    最新の構成でcreateするように修正
# 再現・確認手順

```
$ RAILS_ENV=production bundle exec rake db:seed
```
# 対応Issue（任意）

なし
# ToDo
- [x] ラベル付け
- [x] Assigneesで自分を選択
