### PR TITLE
Add wait_for_ajax for js test

### DIFF
--- a/spec/features/inquiry_spec.rb
+++ b/spec/features/inquiry_spec.rb
@@ -13,7 +13,7 @@ describe InquiriesController, type: :feature do
       page.execute_script %{ $('#new_inquiry').modal('show') }
       find('#inquiry_body').set(body)
       find('button.btn-success').trigger('click')
-      sleep 0.1
+      wait_for_ajax
     end
 
     context 'success' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -63,19 +63,20 @@ RSpec.configure do |config|
   # https://relishapp.com/rspec/rspec-rails/docs
   config.infer_spec_type_from_file_location!
 
-  # Setting for DatabaseRewinder
-  config.before :suite do
-    DatabaseRewinder.clean_all
-  end
-
-  config.after :each do
-    DatabaseRewinder.clean
-  end
-
   # Setting for Devise
   config.include RequestHelpers, type: :request
   config.include RequestHelpers, type: :feature
 
   config.include Helpers
   config.include Capybara::DSL
+
+  # Setting for DatabaseRewinder
+  config.before :suite do
+    DatabaseRewinder.clean_all
+  end
+
+  config.after(:each, js: true) { wait_for_ajax }
+  config.after :each do
+    DatabaseRewinder.clean
+  end
 end

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -13,4 +13,15 @@ module RequestHelpers
 
     login_as user
   end
+
+  # see: http://qiita.com/saboyutaka/items/cafc2b69ae52f605c8fd
+  def wait_for_ajax
+    Timeout.timeout(Capybara.default_wait_time) do
+      loop until finished_all_ajax_requests?
+    end
+  end
+
+  def finished_all_ajax_requests?
+    page.evaluate_script('jQuery.active').zero?
+  end
 end


### PR DESCRIPTION
# 概要

Ajaxを含むテスト内で、ajaxの処理が終わるのを待つ

参考: [CapybaraのJSテストがrandom failする](http://qiita.com/saboyutaka/items/cafc2b69ae52f605c8fd)
# 再現・確認手順

CircleCIのテストが安定して通ることを確認
# 対応Issue（任意）

なし
# ToDo
- [x] ラベル付け
- [x] Assigneesで自分を選択
