### PR TITLE
Dev/306 user has many groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@
   if the directory already exists, remove it before execution.
 1. `bundle exec rake db:create`
 1. `bundle exec rake db:migrate`
+1. `.env` で環境変数をセットアップ
 1. `bundle exec rake db:seed`
 1. `bundle exec rails s`
 1. open http://localhost:3000

--- a/app/admin/group.rb
+++ b/app/admin/group.rb
@@ -1,4 +1,5 @@
 ActiveAdmin.register Group do
+  menu parent: 'グループ'
   csv_importable
   active_admin_action_log
   permit_params { Group.column_names }

--- a/app/admin/group_assignment.rb
+++ b/app/admin/group_assignment.rb
@@ -1,0 +1,19 @@
+ActiveAdmin.register GroupAssignment do
+  menu parent: 'グループ'
+  active_admin_action_log
+  permit_params { GroupAssignment.column_names }
+
+  controller do
+    def scoped_collection
+      super.includes :group, :user
+    end
+  end
+
+  index do
+    id_column
+    column :group
+    column :user
+    column :created_at
+    actions
+  end
+end

--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -4,12 +4,12 @@ ActiveAdmin.register User do
                  after_batch_import: ->(file) { User.last(file.csv_lines.size).each(&:create_profile) }
   active_admin_action_log
   actions :all, except: [:destroy]
-  permit_params :name, :group_id, :employee_code, :email, :entry_date, :beginner_flg,
+  permit_params :name, :employee_code, :email, :entry_date, :beginner_flg,
                 :deleted_at, :password, :password_confirmation, :gender
 
   controller do
     def scoped_collection
-      super.includes :group
+      super.includes :groups
     end
 
     private
@@ -23,7 +23,6 @@ ActiveAdmin.register User do
     selectable_column
     id_column
     column :name
-    column :group
     column :gender, :gender_i18n
     column :employee_code
     column :entry_date
@@ -36,7 +35,6 @@ ActiveAdmin.register User do
   end
 
   filter :name
-  filter :group
   filter :gender, as: :select, collection: User.genders
   filter :employee_code
   filter :email
@@ -49,7 +47,6 @@ ActiveAdmin.register User do
   form do |f|
     f.inputs 'User Details' do
       f.input :name
-      f.input :group
       f.input :gender, as: :select, collection: User.genders.keys
       f.input :employee_code
       f.input :email

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,5 +1,5 @@
 class GroupsController < ApplicationController
   def index
-    @groups = Group.includes(:users).active.order(:id)
+    @groups = Group.includes(users: :user_profile).active.order(:id)
   end
 end

--- a/app/controllers/monthly_reports_controller.rb
+++ b/app/controllers/monthly_reports_controller.rb
@@ -1,6 +1,6 @@
 class MonthlyReportsController < ApplicationController
   def index
-    references = [{ user: :group }, { monthly_report_tags: :tag }]
+    references = [{ user: :groups }, { monthly_report_tags: :tag }]
     @q = MonthlyReport.includes(references).ransack(search_params)
     @monthly_reports = @q.result(distinct: true).released.order('shipped_at desc').page params[:page]
   end
@@ -113,7 +113,7 @@ class MonthlyReportsController < ApplicationController
     params[:q][:tags_name_in] = params[:q][:tags_name_in].split(',')
 
     search_conditions = [
-      :user_group_id_eq,
+      :user_groups_id_eq,
       :user_name_cont,
       tags_name_in: [],
       monthly_working_processes_process_in: [],

--- a/app/mailers/mailer/notify.rb
+++ b/app/mailers/mailer/notify.rb
@@ -9,10 +9,10 @@ module Mailer
     def monthly_report_registration(user_id, monthly_report_id)
       @report = MonthlyReport.find(monthly_report_id)
       @user = User.find(user_id)
-      return unless @user.group
+      return unless @user.groups
 
       @title = "#{@user.name}が#{@report.target_month.strftime('%Y年%m月')}の月報を登録しました"
-      mail(to: @user.group.email, subject: @title)
+      mail(to: @user.groups.map(&:email), subject: @title)
     end
   end
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -12,7 +12,8 @@
 #
 
 class Group < ActiveRecord::Base
-  has_many :users
+  has_many :users, through: :group_assignments, dependent: :destroy
+  has_many :group_assignments
 
   validates :name, presence: true
   validates :email, presence: true, format: { with: /\A[^@]+@[^@]+\z/ }

--- a/app/models/group_assignment.rb
+++ b/app/models/group_assignment.rb
@@ -1,0 +1,18 @@
+# == Schema Information
+#
+# Table name: group_assignments
+#
+#  id         :integer          not null, primary key
+#  group_id   :integer          not null
+#  user_id    :integer          not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
+class GroupAssignment < ActiveRecord::Base
+  belongs_to :group
+  belongs_to :user
+
+  validates :group, presence: true
+  validates :user, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,6 @@
 #
 #  id                     :integer          not null, primary key
 #  name                   :string
-#  group_id               :integer
 #  employee_code          :string
 #  encrypted_email        :string           not null
 #  entry_date             :date
@@ -35,7 +34,8 @@ class User < ActiveRecord::Base
 
   has_one :user_profile, dependent: :destroy
   has_one :role, class_name: 'UserRole', dependent: :destroy
-  belongs_to :group
+  has_many :groups, through: :group_assignments, dependent: :destroy
+  has_many :group_assignments
   has_many :monthly_reports
   has_many :monthly_report_comments
   delegate :admin?, to: :role, allow_nil: true

--- a/app/views/layouts/_report_index.html.slim
+++ b/app/views/layouts/_report_index.html.slim
@@ -1,7 +1,7 @@
 .list-group
   - @monthly_reports.each do |report|
     a.list-group-item href=(monthly_report_path(report))
-      = Array(report.user.group).map { |g| "【#{g.name}G】" }.join
+      = report.user.groups.map { |g| "【#{g.name}G】" }.join
       = "#{report.user.name} - #{report.target_month.strftime("%Y年%m月")}分"
       - tags = report.monthly_report_tags.order('monthly_report_tags.id')
       - tags.first(3).each do |tag|

--- a/app/views/monthly_reports/index.html.slim
+++ b/app/views/monthly_reports/index.html.slim
@@ -6,9 +6,9 @@
     .container
       = search_form_for @q, { class: 'form-horizontal' } do |f|
         .form-group
-          = f.label :user_group_id_eq, 'グループ', class: 'control-label col-xs-2'
+          = f.label :user_groups_id_eq, 'グループ', class: 'control-label col-xs-2'
           .col-xs-10
-            = f.select :user_group_id_eq, options_for_select(Group.pluck(:name, :id), selected: @q.user_group_id_eq), { include_blank: true }, class: 'form-control'
+            = f.select :user_groups_id_eq, options_for_select(Group.pluck(:name, :id), selected: @q.user_groups_id_eq), { include_blank: true }, class: 'form-control'
         .form-group
           = f.label :user_name_cont, '氏名', class: 'control-label col-xs-2'
           .col-xs-10

--- a/app/views/user_profiles/show.html.slim
+++ b/app/views/user_profiles/show.html.slim
@@ -16,7 +16,7 @@
           tr
             th グループ
             td 
-              = @profile.user.group&.name
+              = @profile.user.groups.map { |g| "【#{g.name}】" }.join
           tr
             th 社員番号
             td

--- a/config/locales/activerecord.ja.yml
+++ b/config/locales/activerecord.ja.yml
@@ -2,6 +2,7 @@ ja:
   activerecord: &activerecord
     models:
       group: グループ
+      group_assignment: グループ割当
       help_text: ヘルプテキスト
       inquiry: 問い合わせ
       monthly_report: 月報

--- a/db/migrate/20150910122142_create_users.rb
+++ b/db/migrate/20150910122142_create_users.rb
@@ -2,7 +2,6 @@ class CreateUsers < ActiveRecord::Migration
   def change
     create_table :users do |t|
       t.string :name
-      t.belongs_to :group, index: true
       t.string :employee_code
       t.string :encrypted_email, null: false
       t.date :entry_date

--- a/db/migrate/20161028173116_create_group_assignments.rb
+++ b/db/migrate/20161028173116_create_group_assignments.rb
@@ -1,0 +1,10 @@
+class CreateGroupAssignments < ActiveRecord::Migration
+  def change
+    create_table :group_assignments do |t|
+      t.references :group, index: true, foreign_key: true, null: false
+      t.references :user, index: true, foreign_key: true, null: false
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161009101808) do
+ActiveRecord::Schema.define(version: 20161028173116) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,6 +44,16 @@ ActiveRecord::Schema.define(version: 20161009101808) do
   add_index "active_admin_comments", ["author_type", "author_id"], name: "index_active_admin_comments_on_author_type_and_author_id", using: :btree
   add_index "active_admin_comments", ["namespace"], name: "index_active_admin_comments_on_namespace", using: :btree
   add_index "active_admin_comments", ["resource_type", "resource_id"], name: "index_active_admin_comments_on_resource_type_and_resource_id", using: :btree
+
+  create_table "group_assignments", force: :cascade do |t|
+    t.integer  "group_id",   null: false
+    t.integer  "user_id",    null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_index "group_assignments", ["group_id"], name: "index_group_assignments_on_group_id", using: :btree
+  add_index "group_assignments", ["user_id"], name: "index_group_assignments_on_user_id", using: :btree
 
   create_table "groups", force: :cascade do |t|
     t.string   "name",        null: false
@@ -147,7 +157,6 @@ ActiveRecord::Schema.define(version: 20161009101808) do
 
   create_table "users", force: :cascade do |t|
     t.string   "name"
-    t.integer  "group_id"
     t.string   "employee_code"
     t.string   "encrypted_email",                     null: false
     t.date     "entry_date"
@@ -171,10 +180,11 @@ ActiveRecord::Schema.define(version: 20161009101808) do
   end
 
   add_index "users", ["encrypted_email"], name: "index_users_on_encrypted_email", unique: true, using: :btree
-  add_index "users", ["group_id"], name: "index_users_on_group_id", using: :btree
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
 
   add_foreign_key "active_admin_action_logs", "users"
+  add_foreign_key "group_assignments", "groups"
+  add_foreign_key "group_assignments", "users"
   add_foreign_key "monthly_working_processes", "monthly_reports"
   add_foreign_key "user_profiles", "users"
 end

--- a/spec/factories/group.rb
+++ b/spec/factories/group.rb
@@ -1,7 +1,13 @@
 FactoryGirl.define do
   factory :group do
     name { Faker::Name.name }
-    sequence(:email) { |i| "#{i}#{Faker::Internet.email}" }
+
+    if Rails.env.development?
+      email { ENV['SYSTEM_MAIL'] }
+    else
+      sequence(:email) { |i| "#{i}#{Faker::Internet.email}" }
+    end
+
     description { Faker::Lorem.paragraph }
   end
 end

--- a/spec/factories/group_assignments.rb
+++ b/spec/factories/group_assignments.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :group_assignment do
+    association :group
+    association :user
+  end
+end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -1,11 +1,20 @@
 FactoryGirl.define do
   factory :user do
     name { Faker::Name.name }
-    association :group
     sequence(:employee_code) { |i| "#{i}#{Faker::Number.number(10)}" }
     sequence(:email) { |i| "#{i}#{Faker::Internet.email}" }
     entry_date { Faker::Date.between(3.years.ago, 1.year.ago) }
     beginner_flg { [true, false].sample }
     gender { User.genders.keys.sample }
+
+    transient do
+      group_size 1
+    end
+
+    after(:create) do |user, evaluator|
+      evaluator.group_size.times do
+        create(:group_assignment, user: user)
+      end
+    end
   end
 end

--- a/spec/features/admin/group_spec.rb
+++ b/spec/features/admin/group_spec.rb
@@ -1,7 +1,8 @@
 describe 'Admin::Group', type: :feature do
   before { login(admin: true) }
   let(:group) { create(:group) }
-  let!(:user) { create(:user, group: group) }
+  let(:user) { create(:user) }
+  let!(:assignment) { create(:group_assignment, group: group, user: user) }
   let(:page_title) { find('#page_title') }
 
   describe '#index' do

--- a/spec/features/admin/user_spec.rb
+++ b/spec/features/admin/user_spec.rb
@@ -13,7 +13,6 @@ describe 'Admin::User', type: :feature do
   describe '#show' do
     before { visit admin_user_path(user) }
     it { expect(page_title).to have_content(user.name) }
-    it { expect(page).to have_content(user.group.name) }
     it { expect(page).to have_content('PW変更') }
   end
 

--- a/spec/mailers/notify_spec.rb
+++ b/spec/mailers/notify_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Mailer::Notify, type: :mailer do
     let(:mail_body) { mail.body.encoded.split(/\r\n/).map { |i| Base64.decode64(i) }.join }
     it { expect { mail.deliver_now }.to change { ActionMailer::Base.deliveries.count }.from(0).to(1) }
     it { expect(mail.subject).to eq(title) }
-    it { expect(mail.to).to include(user.group.email) }
+    it { expect(mail.to).to eq user.groups.map(&:email) }
     it { expect(mail.from[0]).to eq(from) }
     it { expect(mail_body).to match(report.project_summary) }
     it { expect(mail_body.force_encoding('UTF-8').scrub).to match(user.name) }

--- a/spec/models/group_assignment_spec.rb
+++ b/spec/models/group_assignment_spec.rb
@@ -1,0 +1,22 @@
+# == Schema Information
+#
+# Table name: group_assignments
+#
+#  id         :integer          not null, primary key
+#  group_id   :integer          not null
+#  user_id    :integer          not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
+describe GroupAssignment, type: :model do
+  describe 'Relations' do
+    it { is_expected.to belong_to :group }
+    it { is_expected.to belong_to :user }
+  end
+
+  describe 'Validations' do
+    it { is_expected.to validate_presence_of(:group) }
+    it { is_expected.to validate_presence_of(:user) }
+  end
+end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -14,6 +14,7 @@
 describe Group, type: :model do
   describe 'Relations' do
     it { is_expected.to have_many :users }
+    it { is_expected.to have_many :group_assignments }
   end
 
   describe 'Validations' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4,7 +4,6 @@
 #
 #  id                     :integer          not null, primary key
 #  name                   :string
-#  group_id               :integer
 #  employee_code          :string
 #  encrypted_email        :string           not null
 #  entry_date             :date
@@ -29,7 +28,8 @@
 
 describe User, type: :model do
   describe 'Relations' do
-    it { is_expected.to belong_to :group }
+    it { is_expected.to have_many :groups }
+    it { is_expected.to have_many :group_assignments }
     it { is_expected.to have_many :monthly_reports }
     it { is_expected.to have_many :monthly_report_comments }
     it { is_expected.to have_one :user_profile }

--- a/spec/requests/group_spec.rb
+++ b/spec/requests/group_spec.rb
@@ -3,11 +3,12 @@ describe GroupsController, type: :request do
 
   describe '#index GET groups' do
     let!(:user) { create(:user) }
+    let(:group) { user.groups.first }
     before { get groups_path }
 
     it { expect(response).to have_http_status :success }
     it { expect(response.body).to match user.name }
-    it { expect(response.body).to match user.group.name }
-    it { expect(response.body).to match user.group.description }
+    it { expect(response.body).to match group.name }
+    it { expect(response.body).to match group.description }
   end
 end

--- a/spec/requests/user_profile_spec.rb
+++ b/spec/requests/user_profile_spec.rb
@@ -10,7 +10,7 @@ describe UserProfilesController, type: :request do
         it { expect(response).to have_http_status :success }
         it { expect(response).to render_template 'user_profiles/show' }
         it { expect(response.body).to match user.name }
-        it { expect(response.body).to match user.group.name }
+        it { expect(response.body).to match user.groups.first.name }
         it { expect(response.body).to match user.employee_code.to_s }
         it { expect(response.body).to match user.email }
         it { expect(response.body).to match user.entry_date.to_s }
@@ -37,8 +37,8 @@ describe UserProfilesController, type: :request do
         it { expect(response.body).not_to match 'プロフィール編集' }
       end
 
-      context 'without group_id' do
-        let(:user) { create(:user, group_id: nil) }
+      context 'not belongs to group' do
+        let(:user) { create(:user, group_size: 0) }
         before { get user_profile_path(user.user_profile) }
         it { expect(response).to have_http_status :success }
         it { expect(response).to render_template 'user_profiles/show' }


### PR DESCRIPTION
# 概要

1人のユーザーが複数のグループに参加できるようにする
- グループ割当（GroupAssignment）を別モデルへと分離
- Userから `group_id` を削除し、複数のグループへ所属できるよう修正
# 再現・確認手順
- 複数グループに所属するユーザーが月報登録した時、各グループにメールが送信されるか
- 各画面で不具合等起きていないか
# 対応Issue（任意）

https://github.com/hr-dash/hr-dash/issues/306
# ToDo
- [x] ラベル付け
- [x] Assigneesで自分を選択
