### PR TITLE
Dev/346 cache user profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,8 @@ node_modules
 *.swp
 
 .env
+
+### Redis ###
+# Ignore redis binary dump (dump.rdb) files
+
+*.rdb

--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ gem 'newrelic_rpm'
 gem 'peek'
 gem 'peek-rblineprof'
 gem 'dotenv-rails'
+gem 'redis-rails'
 
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -307,6 +307,23 @@ GEM
       debugger-ruby_core_source (~> 1.3)
     rchardet (1.6.1)
     rdoc (4.2.0)
+    redis (3.3.1)
+    redis-actionpack (5.0.0)
+      actionpack (>= 4.0.0, < 6)
+      redis-rack (~> 2.0.0.pre)
+      redis-store (~> 1.2.0.pre)
+    redis-activesupport (5.0.1)
+      activesupport (>= 3, < 6)
+      redis-store (~> 1.2.0)
+    redis-rack (2.0.0.pre)
+      rack (> 1.5, < 3)
+      redis-store (~> 1.2.0.pre)
+    redis-rails (5.0.1)
+      redis-actionpack (~> 5.0.0)
+      redis-activesupport (~> 5.0.0)
+      redis-store (~> 1.2.0)
+    redis-store (1.2.0)
+      redis (>= 2.2)
     reek (4.5.1)
       codeclimate-engine-rb (~> 0.4.0)
       parser (~> 2.3.1, >= 2.3.1.2)
@@ -452,6 +469,7 @@ DEPENDENCIES
   rack_session_access
   rails (~> 4.2.7)
   rails-erd
+  redis-rails
   reek
   rspec
   rspec-rails

--- a/app/views/layouts/_report_index.html.slim
+++ b/app/views/layouts/_report_index.html.slim
@@ -1,11 +1,8 @@
 .list-group
-  - cache @monthly_reports do
-    - @monthly_reports.each do |report|
-      a.list-group-item href=(monthly_report_path(report))
-        = Array(report.user.group).map { |g| "【#{g.name}G】" }.join
-        = "#{report.user.name} - #{report.target_month.strftime("%Y年%m月")}分"
-        - tags = report.monthly_report_tags.order('monthly_report_tags.id')
-        - tags.first(3).each do |tag|
-          - cache tag do
-            span.badge = tag.name
-
+  - @monthly_reports.each do |report|
+    a.list-group-item href=(monthly_report_path(report))
+      = Array(report.user.group).map { |g| "【#{g.name}G】" }.join
+      = "#{report.user.name} - #{report.target_month.strftime("%Y年%m月")}分"
+      - tags = report.monthly_report_tags.order('monthly_report_tags.id')
+      - tags.first(3).each do |tag|
+        span.badge = tag.name

--- a/app/views/layouts/_report_index.html.slim
+++ b/app/views/layouts/_report_index.html.slim
@@ -1,8 +1,11 @@
 .list-group
-  - @monthly_reports.each do |report|
-    a.list-group-item href=(monthly_report_path(report))
-      = Array(report.user.group).map { |g| "【#{g.name}G】" }.join
-      = "#{report.user.name} - #{report.target_month.strftime("%Y年%m月")}分"
-      - tags = report.monthly_report_tags.order('monthly_report_tags.id')
-      - tags.first(3).each do |tag|
-        span.badge = tag.name
+  - cache @monthly_reports do
+    - @monthly_reports.each do |report|
+      a.list-group-item href=(monthly_report_path(report))
+        = Array(report.user.group).map { |g| "【#{g.name}G】" }.join
+        = "#{report.user.name} - #{report.target_month.strftime("%Y年%m月")}分"
+        - tags = report.monthly_report_tags.order('monthly_report_tags.id')
+        - tags.first(3).each do |tag|
+          - cache tag do
+            span.badge = tag.name
+

--- a/app/views/user_profiles/show.html.slim
+++ b/app/views/user_profiles/show.html.slim
@@ -3,44 +3,45 @@
 .page-content
   .jumbotron
     section
-      h2.profile-heading
-        span.glyphicon.glyphicon-user
-        span
-          = @profile.user.name
-      - if current_user == @profile.user
-        .edit-profile
-          = link_to('プロフィール編集', edit_user_profile_path(@profile))
-      = link_to 'このユーザーの月報を閲覧', user_monthly_reports_path(@profile.user), class: 'pull-right'
-      table.table
-        tbody
-          tr
-            th グループ
-            td 
-              = @profile.user.group&.name
-          tr
-            th 社員番号
-            td
-              = @profile.user.employee_code
-          tr
-            th メールアドレス
-            td
-              = @profile.user.email
-          tr
-            th 入社日
-            td
-              = @profile.user.entry_date
-          tr
-            th 性別
-            td
-              = @profile.user.gender_i18n
-          tr
-            th 血液型
-            td
-              = @profile.blood_type_i18n
-          tr
-            th 誕生日
-            td
-              = @profile.birthday || '未入力'
+      - cache @profile do
+        h2.profile-heading
+          span.glyphicon.glyphicon-user
+          span
+            = @profile.user.name
+        - if current_user == @profile.user
+          .edit-profile
+            = link_to('プロフィール編集', edit_user_profile_path(@profile))
+        = link_to 'このユーザーの月報を閲覧', user_monthly_reports_path(@profile.user), class: 'pull-right'
+        table.table
+          tbody
+            tr
+              th グループ
+              td
+                = @profile.user.group&.name
+            tr
+              th 社員番号
+              td
+                = @profile.user.employee_code
+            tr
+              th メールアドレス
+              td
+                = @profile.user.email
+            tr
+              th 入社日
+              td
+                = @profile.user.entry_date
+            tr
+              th 性別
+              td
+                = @profile.user.gender_i18n
+            tr
+              th 血液型
+              td
+                = @profile.blood_type_i18n
+            tr
+              th 誕生日
+              td
+                = @profile.birthday || '未入力'
     section
       h2.profile-heading 自己紹介
       pre

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -11,7 +11,7 @@ Rails.application.configure do
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true
-  config.action_controller.perform_caching = false
+  config.action_controller.perform_caching = true
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
@@ -65,4 +65,6 @@ Rails.application.configure do
     authentication:        'plain',
     enable_starttls_auto:  true
   }
+
+  config.cache_store = :redis_store, ENV['REDIS_URL'], { expires_in: 30.minutes }
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -80,4 +80,6 @@ Rails.application.configure do
   # ActionMailerの設定
   config.action_mailer.default_url_options = { :host => ENV['MAILER_DEFAULT_HOST'] }
   config.action_mailer.default_options = { from: "システム管理者 <#{ENV['MAILER_FROM']}>" }
+
+  config.cache_store = :redis_store, ENV['REDIS_URL'], { expires_in: 30.minutes }
 end


### PR DESCRIPTION
# 概要
Redisにプロフィールをキャッシュするようにしてみた。
そこまで大きく速度が変化するわけではなく、
「こんな感じのコードでできるようです」といった意味合いで見やすいだろうと思ってプルリクあげました。
なのでUserProfileのキャッシュは不要！とのことであればそのままcloseにしようかと思っています。

- before  
37.1ms + 3.1ms app/views/user_profiles/show.html.slim
- after  
4.9ms + 1.5ms app/views/user_profiles/show.html.slim

相談したいことが2点あって、

1. そもそもcache_storeはRedisで良いのか  
個人的にはAWSでの運用であまりお金とか気にしなくて良さそう（？）な `ActiveSupport::Cache::MemoryStore` でも良いのかなと思っています。  
AWS詳しくなく、かなり適当なのでどなたかご意見をいただければ...  
ただ、cache_sotre変更するだけであれば、そこまで手間ではない（ソースコードの変更だけであれば）と思うので、後から変更でも良いかなと思っています。
2. キャッシュの有効期限どうするか  
UserProfileだとそこまで変更あるとは思えないので、まだまだ長くとっても良いかなと思っています。

# 再現・確認手順

## 速度確認

1. `.env` に以下を追記
ただし、すでにローカルでRedisを利用している方は **/0/** の部分に注意！
**/1/** とか使ってないとこに変更すると良いはず。
```
REDIS_URL=redis://localhost:6379/0/cache
```
2. サーバー起動, Redis起動  
  ```
  $ bundle exec rails s
  $ redis-server
  ```
3. [プロフィール画面](http://localhost:3000/user_profiles/125?lineprofiler=app)へアクセス
4. リロード（初回でキャッシュさせる必要があるため）
5. `app/views/user_profiles/show.html.slim` を確認

## プロフィールの更新が反映されるか
- `rails console` で

# 対応Issue（任意）
#346 

# ToDo

- [x] ラベル付け
- [x] Assigneesで自分を選択
