### PR TITLE
エラーを通知する

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -14,6 +14,7 @@ class ErrorsController < ActionController::Base
 
   def render_internal_server_error(exception = nil)
     if exception
+      Mailer::Error.create(exception, current_user, request).deliver_now
       logger.info "Rendering 500 with exception: #{exception.message}"
     end
     render template: 'errors/500', status: 500

--- a/app/mailers/mailer/error.rb
+++ b/app/mailers/mailer/error.rb
@@ -1,0 +1,12 @@
+module Mailer
+  class Error < ApplicationMailer
+    def create(exception, user, request)
+      @exception = exception
+      @user = user
+      @request = request
+
+      @title = "#{exception.class} が発生しました"
+      mail(to: ENV['SYSTEM_MAIL'], subject: @title)
+    end
+  end
+end

--- a/app/views/mailer/error/create.html.slim
+++ b/app/views/mailer/error/create.html.slim
@@ -1,0 +1,31 @@
+p = @title
+br
+
+p = "【送信時刻】 #{Time.current}"
+br
+
+p 【リクエスト】
+- if @request
+  p = "RequestURI: #{@request.env["REQUEST_URI"]}"
+  p = "RequestMethod: #{@request.env["REQUEST_METHOD"]}"
+  p = "Referer: #{@request.referer}"
+  p = "UserAgent: #{@request.user_agent}"
+- else
+  p なし
+br
+
+p 【ログインユーザー】
+- if @user
+  p = "ID: #{@user.id}"
+  p = "NAME: #{@user.name}"
+- else
+  p なし
+br
+
+p 【エラーメッセージ】
+p = @exception.class
+p = @exception.message
+p -----------------
+pre = @exception.backtrace.join("\n")
+p -----------------
+

--- a/spec/requests/errors_spec.rb
+++ b/spec/requests/errors_spec.rb
@@ -1,10 +1,13 @@
 describe ErrorsController, type: :request do
+  after { ActionMailer::Base.deliveries.clear }
+
   describe '404' do
     context 'ActionController::RoutingError' do
       before { get '/page_not_found' }
 
       it { expect(response).to have_http_status :not_found }
       it { expect(response).to render_template('errors/404') }
+      it { expect(ActionMailer::Base.deliveries.size).to eq(0) }
     end
 
     context 'ActiveRecord::RecordNotFound' do
@@ -15,6 +18,7 @@ describe ErrorsController, type: :request do
 
       it { expect(response).to have_http_status :not_found }
       it { expect(response).to render_template('errors/404') }
+      it { expect(ActionMailer::Base.deliveries.size).to eq(0) }
     end
   end
 
@@ -27,6 +31,7 @@ describe ErrorsController, type: :request do
 
       it { expect(response).to have_http_status :error }
       it { expect(response).to render_template('errors/500') }
+      it { expect(ActionMailer::Base.deliveries.size).to eq(1) }
     end
   end
 end


### PR DESCRIPTION
# 概要
エラーをメールで通知する
忘れてたので対応

# 再現・確認手順
`.env` はセットアップ済前提。
開発環境の場合、 `config/environments/development.rb` で
```ruby
config.consider_all_requests_local       = false
```
を指定し、どこかで適当に 500 エラーを発生させてみる。
メール通知が飛んでくればOK。

# 対応Issue（任意）
https://github.com/hr-dash/hr-dash/issues/353

# ToDo

- [x] ラベル付け
- [x] Assigneesで自分を選択
