### PR TITLE
Add settings for production mail

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -78,6 +78,7 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   # ActionMailerの設定
+  config.action_mailer.delivery_method = :aws_sdk
   config.action_mailer.default_url_options = { :host => ENV['MAILER_DEFAULT_HOST'] }
   config.action_mailer.default_options = { from: "システム管理者 <#{ENV['MAILER_FROM']}>" }
 end

--- a/config/initializers/aws_ses.rb
+++ b/config/initializers/aws_ses.rb
@@ -1,3 +1,4 @@
 if Rails.env.production?
-  Aws::Rails.add_action_mailer_delivery_method(:aws_sdk, { region: ENV['AWS_SES_REGION'] })
+  creds = Aws::Credentials.new(ENV['AWS_ACCESS_KEY_ID'], ENV['AWS_SECRET_ACCESS_KEY'])
+  Aws::Rails.add_action_mailer_delivery_method(:aws_sdk, credentials: creds, region: ENV['AWS_SES_REGION'])
 end


### PR DESCRIPTION
# 概要
本番用のSESの設定不足があったため、追加定義。

# 再現・確認手順
ログから `Aws::SES::Client` が使われていることを確認

# 対応Issue（任意）

# ToDo

- [x] ラベル付け
- [x] Assigneesで自分を選択
