### PR TITLE
Dev/fix user import

### DIFF
--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -64,7 +64,8 @@ ActiveAdmin.register User do
   collection_action :import_csv, method: :post do
     unless params[:csv]
       flash[:error] = 'CSVファイルを指定してください'
-      redirect_to :back && return
+      redirect_to :back
+      return
     end
 
     users = []

--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -70,12 +70,14 @@ ActiveAdmin.register User do
 
     users = []
     errors = []
+    index = 1 # CSVヘッダー行
     CSV.table(params[:csv].tempfile, encoding: 'sjis').each do |line|
+      index += 1
       user = User.new(line.to_h)
       if user.valid?
         users << user
       else
-        errors += user.errors.full_messages
+        errors += user.errors.full_messages.map { |msg| "(#{index}行目)#{msg}" }
       end
     end
 

--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -64,7 +64,7 @@ ActiveAdmin.register User do
   collection_action :import_csv, method: :post do
     unless params[:csv]
       flash[:error] = 'CSVファイルを指定してください'
-      redirect_to :back and return
+      redirect_to :back && return
     end
 
     users = []

--- a/app/views/admin/users/input_csv.html.slim
+++ b/app/views/admin/users/input_csv.html.slim
@@ -1,0 +1,8 @@
+= form_tag import_csv_admin_users_path, method: :post, multipart: true, html: { class: 'formastic' } do
+  fieldset.inputs
+    legend
+      span インポートするCSVを指定
+    ol = file_field_tag :csv
+  fieldset.actions
+    ol = submit_tag 'インポートする'
+

--- a/spec/features/admin/user_spec.rb
+++ b/spec/features/admin/user_spec.rb
@@ -33,6 +33,39 @@ describe 'Admin::User', type: :feature do
     it { expect(current_path).to eq admin_user_path(user) }
   end
 
+  describe '#import_csv' do
+    before { visit input_csv_admin_users_path }
+
+    context 'no input csv file' do
+      before { click_on 'インポートする' }
+
+      it { expect(current_path).to eq input_csv_admin_users_path }
+      it { expect(page).to have_content('CSVファイルを指定してください') }
+    end
+
+    context 'input valid csv file' do
+      let(:file) { File.join(fixture_path, 'users.csv') }
+      let(:yamada) { User.find_by(name: '山田 太郎') }
+      let(:suzuki) { User.find_by(name: '鈴木 花子') }
+
+      before do
+        attach_file 'csv', file
+        click_on 'インポートする'
+      end
+
+      it { expect(current_path).to eq admin_users_path }
+      it { expect(page).to have_content('2名のユーザーがインポートされました') }
+      it { expect(yamada).to be_present }
+      it { expect(yamada.email).to eq 'yamada.taro@example.com' }
+      it { expect(yamada.gender).to eq 'male' }
+      it { expect(yamada.beginner_flg).to eq true }
+      it { expect(suzuki).to be_present }
+      it { expect(suzuki.email).to eq 'suzuki.hanako@example.com' }
+      it { expect(suzuki.gender).to eq 'female' }
+      it { expect(suzuki.beginner_flg).to eq false }
+    end
+  end
+
   describe '#update_password' do
     let(:other_user) { create(:user) }
     let(:new_password) { generate_random_password }

--- a/spec/features/admin/user_spec.rb
+++ b/spec/features/admin/user_spec.rb
@@ -59,10 +59,12 @@ describe 'Admin::User', type: :feature do
       it { expect(yamada.email).to eq 'yamada.taro@example.com' }
       it { expect(yamada.gender).to eq 'male' }
       it { expect(yamada.beginner_flg).to eq true }
+      it { expect(yamada.user_profile).to be_present }
       it { expect(suzuki).to be_present }
       it { expect(suzuki.email).to eq 'suzuki.hanako@example.com' }
       it { expect(suzuki.gender).to eq 'female' }
       it { expect(suzuki.beginner_flg).to eq false }
+      it { expect(suzuki.user_profile).to be_present }
     end
   end
 

--- a/spec/fixtures/users.csv
+++ b/spec/fixtures/users.csv
@@ -1,0 +1,1 @@
+name,email,employee_code,gender,beginner_flg,entry_date山田 太郎,yamada.taro@example.com,ABC11001,male,TRUE,2016/1/1鈴木 花子,suzuki.hanako@example.com,ABC11002,female,FALSE,2016/2/1


### PR DESCRIPTION
# 概要
ユーザーのCSVインポート機能が壊れていたので修正
Gemの `active_admin_import` だと `encrypted_email` への変換がつらいので、action_item, collection_actionを使って自前で実装。
今回はテストを追加した。

# 再現・確認手順
`spec/fixtures/users.csv` を元に、適当に値をいじって管理画面からインポートしてみる。
CSVファイルはExcelで作成することを想定。

# 対応Issue（任意）

# ToDo

- [x] ラベル付け
- [x] Assigneesで自分を選択
