### PR TITLE
下書き登録時にメール通知しない

### DIFF
--- a/app/controllers/monthly_reports_controller.rb
+++ b/app/controllers/monthly_reports_controller.rb
@@ -133,7 +133,7 @@ class MonthlyReportsController < ApplicationController
   end
 
   def monthly_report_notify(shipped_at_was)
-    return if shipped_at_was.present?
+    return if shipped_at_was.present? || params[:wip]
     Mailer::Notify.monthly_report_registration(current_user.id, @monthly_report.id).deliver_now
   end
 end

--- a/spec/requests/monthly_report_spec.rb
+++ b/spec/requests/monthly_report_spec.rb
@@ -132,7 +132,7 @@ describe MonthlyReportsController, type: :request do
         it { expect { subject }.to change { ActionMailer::Base.deliveries.size }.by(1) }
       end
 
-      context 'registered as whipped' do
+      context 'registered as wip' do
         let(:post_params) { { monthly_report: report_params, wip: true } }
         subject { post monthly_reports_path, post_params }
         it { expect(ActionMailer::Base.deliveries.size).to eq(0) }

--- a/spec/requests/monthly_report_spec.rb
+++ b/spec/requests/monthly_report_spec.rb
@@ -134,7 +134,7 @@ describe MonthlyReportsController, type: :request do
 
       context 'registered as wip' do
         let(:post_params) { { monthly_report: report_params, wip: true } }
-        subject { post monthly_reports_path, post_params }
+        before { post monthly_reports_path, post_params }
         it { expect(ActionMailer::Base.deliveries.size).to eq(0) }
       end
     end


### PR DESCRIPTION
# 概要
下書き登録時にメール通知しない

# 再現・確認手順
下書き保存の場合と、保存して公開の場合でメール通知が飛ぶかどうかをそれぞれ確認

# 対応Issue（任意）
https://github.com/hr-dash/hr-dash/issues/362

# ToDo

- [x] ラベル付け
- [x] Assigneesで自分を選択
