### PR TITLE
Dev/366 tag ignore case

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,6 +68,7 @@ group :development, :test do
   gem 'bullet'
 
   gem 'rspec-rails'
+  gem 'rspec_rake'
   gem 'factory_girl_rails'
   gem 'faker'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -347,6 +347,8 @@ GEM
       rspec-mocks (~> 3.3.0)
       rspec-support (~> 3.3.0)
     rspec-support (3.3.0)
+    rspec_rake (1.0.0)
+      rake
     rubocop (0.32.1)
       astrolabe (~> 1.3)
       parser (>= 2.2.2.5, < 3.0)
@@ -474,6 +476,7 @@ DEPENDENCIES
   reek
   rspec
   rspec-rails
+  rspec_rake
   rubocop
   sass-rails (~> 5.0, >= 5.0.6)
   sdoc (~> 0.4.0)

--- a/app/controllers/monthly_reports_controller.rb
+++ b/app/controllers/monthly_reports_controller.rb
@@ -85,7 +85,7 @@ class MonthlyReportsController < ApplicationController
 
   def monthly_report_tags
     tags = params[:monthly_report][:monthly_report_tags].try!(:split, ',').try!(:map) do |name|
-      tag = Tag.find_or_initialize_by(name: name.strip)
+      tag = Tag.find_or_initialize_by_name_ignore_case(name.strip)
       tag.save ? tag : nil # 許容できないタグは無視
     end.try!(:compact)
 

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -16,4 +16,8 @@ class Tag < ActiveRecord::Base
   validates :name, length: { maximum: 32 }, presence: true, format: { with: VALID_NAME_REGEX }
 
   enum status: { unfixed: 0, fixed: 1 }
+
+  def self.find_or_initialize_by_name_ignore_case(name)
+    Tag.where('LOWER(name) = LOWER(?)', name).first || Tag.new(name: name)
+  end
 end

--- a/lib/tasks/tag_cleaner.rake
+++ b/lib/tasks/tag_cleaner.rake
@@ -1,0 +1,13 @@
+namespace :tag_cleaner do
+  desc 'Print duplicate tags in ignore case'
+  task duplicate_list: :environment do
+    duplicate_tags = Tag.all.group_by { |tag| tag.name.downcase }.select { |_, tags| tags.size > 1 }
+    duplicate_tags.each do |name, tags|
+      puts "Duplicate Tag: #{name}"
+      tags.each do |tag|
+        referenced_count = MonthlyReportTag.where(tag: tag).count
+        puts "  id: #{tag.id}, name: #{tag.name}, status: #{tag.status}, referenced_count: #{referenced_count}"
+      end
+    end
+  end
+end

--- a/lib/tasks/tag_cleaner.rake
+++ b/lib/tasks/tag_cleaner.rake
@@ -1,4 +1,14 @@
 namespace :tag_cleaner do
+  desc 'Delete unfixed, unused tags. if no args, dry_run.'
+  task :delete_unused_tags, ['exec_flag'] => :environment do |_, args|
+    Tag.unfixed.each do |tag|
+      tags = MonthlyReportTag.where(tag: tag)
+      next if tags.size > 0
+      puts "Unused tag: #{tag.name}"
+      tag.destroy if args.exec_flag
+    end
+  end
+
   desc 'Print duplicate tags in ignore case'
   task duplicate_list: :environment do
     duplicate_tags = Tag.all.group_by { |tag| tag.name.downcase }.select { |_, tags| tags.size > 1 }

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -46,4 +46,27 @@ describe Tag, type: :model do
       end
     end
   end
+
+  describe '.find_or_initialize_by_name_ignore_case' do
+    let!(:tag) { create(:tag, name: 'Ruby') }
+    subject { Tag.find_or_initialize_by_name_ignore_case(name) }
+
+    context 'exactly match' do
+      let(:name) { 'Ruby' }
+      it { is_expected.to eq tag }
+      it { is_expected.not_to be_new_record }
+    end
+
+    context 'match in ignore case' do
+      let(:name) { 'ruby' }
+      it { is_expected.to eq tag }
+      it { is_expected.not_to be_new_record }
+    end
+
+    context 'not match' do
+      let(:name) { 'Rails' }
+      it { is_expected.not_to eq tag }
+      it { is_expected.to be_new_record }
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -39,6 +39,11 @@ Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 # If you are not using ActiveRecord, you can remove this line.
 ActiveRecord::Migration.maintain_test_schema!
 
+RSpecRake.configure do |config|
+  config.require_tasks(File.join(Rails.root, 'lib', 'tasks'))
+  config.auto_reenable = true
+end
+
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"

--- a/spec/tasks/tag_cleaner_spec.rb
+++ b/spec/tasks/tag_cleaner_spec.rb
@@ -13,7 +13,7 @@ describe 'tag_cleaner' do
     end
 
     context 'exec delete' do
-      before { Rake::Task['tag_cleaner:delete_unused_tags'].invoke "true" }
+      before { Rake::Task['tag_cleaner:delete_unused_tags'].invoke 'true' }
       it { expect(used_tag.reload).to be_present }
       it { expect { unused_tag.reload }.to raise_error(ActiveRecord::RecordNotFound) }
       it { expect(fixed_tag.reload).to be_present }

--- a/spec/tasks/tag_cleaner_spec.rb
+++ b/spec/tasks/tag_cleaner_spec.rb
@@ -1,0 +1,22 @@
+describe 'tag_cleaner' do
+  describe 'delete_unused_tags' do
+    let(:used_tag) { create(:tag, status: :unfixed) }
+    let!(:unused_tag) { create(:tag, status: :unfixed) }
+    let!(:fixed_tag) { create(:tag, status: :fixed) }
+    before { create(:monthly_report_tag, tag: used_tag) }
+
+    context 'dry_run' do
+      before { Rake::Task['tag_cleaner:delete_unused_tags'].invoke }
+      it { expect(used_tag.reload).to be_present }
+      it { expect(unused_tag.reload).to be_present }
+      it { expect(fixed_tag.reload).to be_present }
+    end
+
+    context 'exec delete' do
+      before { Rake::Task['tag_cleaner:delete_unused_tags'].invoke "true" }
+      it { expect(used_tag.reload).to be_present }
+      it { expect { unused_tag.reload }.to raise_error(ActiveRecord::RecordNotFound) }
+      it { expect(fixed_tag.reload).to be_present }
+    end
+  end
+end


### PR DESCRIPTION
# 概要
タグ登録時にIgnoreCaseしたい
月報登録時に `LOWER` で小文字にして検索

Rakeタスクを追加
- ignore caseして重複しているタグの表示
- 未使用かつunfixedのタグの削除

# 再現・確認手順
大文字／小文字が異なるタグを登録しても、重複してタグが登録されないこと

# 対応Issue（任意）
https://github.com/hr-dash/hr-dash/issues/366

# ToDo

- [x] ラベル付け
- [x] Assigneesで自分を選択
