### PR TITLE
グループ割当てしやすくする

### DIFF
--- a/app/admin/group.rb
+++ b/app/admin/group.rb
@@ -52,4 +52,16 @@ ActiveAdmin.register Group do
   member_action :edit_group_assign, method: :get do
     @group = resource
   end
+
+  member_action :update_group_assign, method: :post do
+    @group = resource
+    @group.users = User.where(id: params[:user_ids])
+
+    if @group.save
+      redirect_to action: :show
+    else
+      flash[:error] = @group.errors.full_messages
+      redirect_to :back
+    end
+  end
 end

--- a/app/admin/group.rb
+++ b/app/admin/group.rb
@@ -5,6 +5,18 @@ ActiveAdmin.register Group do
   permit_params { Group.column_names }
   actions :all, except: [:destroy]
 
+  index do
+    id_column
+    column :name
+    column :email
+    column :description
+    column :deleted_at
+    actions do |group|
+      br
+      link_to '割当を編集', edit_group_assign_admin_group_path(group)
+    end
+  end
+
   show do
     attributes_table do
       row :id
@@ -31,5 +43,13 @@ ActiveAdmin.register Group do
       f.input :deleted_at, as: :datepicker
     end
     f.actions
+  end
+
+  action_item :group_assign, only: [:show, :edit] do
+    link_to 'グループ割当を編集する', edit_group_assign_admin_group_path(group)
+  end
+
+  member_action :edit_group_assign, method: :get do
+    @group = resource
   end
 end

--- a/app/admin/group.rb
+++ b/app/admin/group.rb
@@ -55,9 +55,21 @@ ActiveAdmin.register Group do
 
   member_action :update_group_assign, method: :post do
     @group = resource
+    users_before = @group.users.map(&:name)
+
     @group.users = User.where(id: params[:user_ids])
 
     if @group.save
+      users_after = @group.users.map(&:name)
+
+      ActiveAdminActionLog.create do |log|
+        log.user = current_user
+        log.resource = resource
+        log.path = resource_path
+        log.action = action_name
+        log.changes_log = { 'users' => [users_before, users_after] }
+      end
+
       redirect_to action: :show
     else
       flash[:error] = @group.errors.full_messages

--- a/app/views/admin/groups/edit_group_assign.html.slim
+++ b/app/views/admin/groups/edit_group_assign.html.slim
@@ -1,0 +1,13 @@
+= form_tag update_group_assign_admin_group_path(@group), html: { class: 'formastic' } do |f|
+  fieldset.inputs
+    legend
+      span = "#{@group.name} グループの割当を編集"
+    ol
+      li
+        - group_user_ids = @group.users.map(&:id)
+        - User.all.each do |user|
+          = check_box_tag 'user_ids[]', user.id, group_user_ids.include?(user.id), id: "user_id_#{user.id}"
+          span = user.name
+          span = "　"
+  fieldset.actions
+    ol = submit_tag '更新する'

--- a/spec/features/admin/group_spec.rb
+++ b/spec/features/admin/group_spec.rb
@@ -46,4 +46,19 @@ describe 'Admin::Group', type: :feature do
     it { expect(page).to have_content(new_description) }
     it { expect(group.reload.description).to eq new_description }
   end
+
+  describe '#update_group_assign' do
+    let!(:another_user) { create(:user) }
+    before do
+      visit edit_group_assign_admin_group_path(group)
+      check "user_id_#{another_user.id}"
+      uncheck "user_id_#{user.id}"
+      click_on '更新する'
+    end
+
+    it { expect(page_title).to have_content(group.name) }
+    it { expect(current_path).to eq admin_group_path(group) }
+    it { expect(group.users).to include(another_user) }
+    it { expect(group.users).not_to include(user) }
+  end
 end


### PR DESCRIPTION
# 概要
管理画面からグループ割当てするのがつらいので専用の画面を作った。
一画面で、チェックボックスにチェックをつけていく方式
選択中のユーザー一覧とか表示したい気もするけど https://github.com/hr-dash/hr-dash/issues/370 やってからの方が良さそう

# 再現・確認手順
管理画面→グループ→割当を編集

# 対応Issue（任意）
https://github.com/hr-dash/hr-dash/issues/361

# ToDo

- [x] ラベル付け
- [x] Assigneesで自分を選択
