### PR TITLE
ログローテート設定

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -53,6 +53,7 @@ Rails.application.configure do
 
   # Use a different logger for distributed setups.
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
+  config.logger = Logger.new('log/production.log', 'daily')
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store


### PR DESCRIPTION
# 概要
application log を daily で保存する。
削除は別途対応。

# 再現・確認手順
http://qiita.com/yu_0105/items/ac2e49770e5313f31ceb
http://ja.stackoverflow.com/questions/11929/rails-logger%E3%81%8C%E3%83%AD%E3%83%BC%E3%83%86%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3%E3%81%97%E3%81%AA%E3%81%84
ローカルでの確認はちょっと面倒くさそう。

> サーバーは常時起動ではなく、止めたり、起動したりしています。
に関しては、サーバの起動時に次回のローテーション時刻を設定しているため、
サーバを止めると無効になると考えます。
Logger.new の際に、
LogDevice.new され、
@next_rotate_time に更新日が記憶され、
write の度に、check_shift_log を行い、
next_rotate_time に達していたら、shift_log_period で今のファイルをローテーションする、
という動作のようです。

# 対応Issue（任意）
https://github.com/hr-dash/hr-dash/issues/374

# ToDo

- [x] ラベル付け
- [x] Assigneesで自分を選択

