### PR TITLE
月報を削除できるようにしておく

### DIFF
--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -142,7 +142,7 @@ ActiveAdmin.register User do
   end
 
   action_item :delete_monthly_report, only: :show do
-    if !user.active_for_authentication?
+    unless user.active_for_authentication?
       link_to('月報を削除する',
               delete_monthly_report_admin_user_path(user),
               method: :delete,

--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -15,6 +15,15 @@ ActiveAdmin.register User do
     def password_params
       params.require(:user).permit(:password, :password_confirmation)
     end
+
+    def action_log(user:, resource:, path:, action:)
+      ActiveAdminActionLog.create do |log|
+        log.user = user
+        log.resource = resource
+        log.path = path
+        log.action = action
+      end
+    end
   end
 
   index do
@@ -104,17 +113,40 @@ ActiveAdmin.register User do
     @user.assign_attributes(password_params)
 
     if @user.save
-      ActiveAdminActionLog.create do |log|
-        log.user = current_user
-        log.resource = resource
-        log.path = resource_path
-        log.action = action_name
-      end
+      action_log(user: current_user,
+                 resource: resource,
+                 path: resource_path,
+                 action: action_name)
 
       redirect_to action: :index
     else
       flash[:error] = @user.errors.full_messages
       redirect_to :back
+    end
+  end
+
+  member_action :delete_monthly_report, method: :delete do
+    monthly_reports = resource.monthly_reports
+    if !resource.active_for_authentication? && monthly_reports.destroy_all
+      action_log(user: current_user,
+                 resource: resource,
+                 path: resource_path,
+                 action: action_name)
+
+      flash[:success] = '月報を削除しました'
+    else
+      flash[:error] = '月報の削除に失敗しました'
+    end
+
+    redirect_to :back
+  end
+
+  action_item :delete_monthly_report, only: :show do
+    if !user.active_for_authentication?
+      link_to('月報を削除する',
+              delete_monthly_report_admin_user_path(user),
+              method: :delete,
+              data: { confirm: '本当に削除してもよろしいですか？' })
     end
   end
 end


### PR DESCRIPTION
# 概要
退職者の月報とそれに紐づく情報を物理削除する機能の追加

# 再現・確認手順
1. 管理画面から任意のユーザー（以降 A）の詳細ページへ移動する
1. 画面右上に「月報を削除する」ボタンが **表示されていない** ことを確認
1. 「ユーザーを編集する」ボタンから編集画面へ遷移
1. 退社日を入力してsubmit
1. Aの詳細画面へ遷移するので、右上に「月報を削除する」ボタンが **表示されている** ことを確認
1. 「月報を削除する」ボタンを押下し、Aのすべての月報とそれらに紐づく情報が削除されていることを確認する

# 対応Issue（任意）
#369

# ToDo

- [x] ラベル付け
- [x] Assigneesで自分を選択

