### PR TITLE
friendly forwarding

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,7 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
+  before_action :store_current_location, unless: :devise_controller?
   before_action :authenticate_user!
 
   def current_user
@@ -18,5 +19,12 @@ class ApplicationController < ActionController::Base
     authenticate_or_request_with_http_basic do |username, password|
       username == ENV['BASIC_AUTH_USERNAME'] && password == ENV['BASIC_AUTH_PASSWORD']
     end
+  end
+
+  private
+
+  def store_current_location
+    return if current_user
+    store_location_for(:user, request.url)
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,10 +1,20 @@
 class SessionsController < Devise::SessionsController
   layout false
 
-  before_action :reset_session, only: :create
+  before_action :reset_session_before_login, only: :create
 
   def password_reset
     reset_session
     redirect_to new_password_reset_path
+  end
+
+  private
+
+  def reset_session_before_login
+    user_return_to = session[:user_return_to]
+    reset_session
+
+    # friendly forwarding
+    session[:user_return_to] = user_return_to if user_return_to
   end
 end

--- a/spec/features/session_spec.rb
+++ b/spec/features/session_spec.rb
@@ -40,6 +40,32 @@ describe SessionsController, type: :feature do
     end
   end
 
+  describe 'friendly forwarding' do
+    let(:user) { create(:user) }
+    let!(:role) { create(:user_role, :admin, user: user) }
+
+    before do
+      # user hasn't login, so redirect_to new_session_path
+      visit landing_url
+
+      fill_in 'email', with: user.email
+      fill_in 'password', with: user.password
+      click_on 'Login'
+    end
+
+    context 'user report page' do
+      let(:landing_url) { user_monthly_reports_path(user) }
+      it { expect(page).to have_http_status :success }
+      it { expect(current_path).to eq(landing_url) }
+    end
+
+    context 'admin page' do
+      let(:landing_url) { admin_users_path }
+      it { expect(page).to have_http_status :success }
+      it { expect(current_path).to eq(landing_url) }
+    end
+  end
+
   describe '#destroy DELETE /sessions/destroy' do
     let(:user) { create(:user) }
     before do


### PR DESCRIPTION
# 概要
フレンドリーフォワーディングを実装する

基本的にDeviseのHowToに則った方式で実装したが、セキュリティ対策でログイン時に `reset_session` した部分を考慮している

参考
- [How To: Redirect back to current page after sign in, sign out, sign up, update](https://github.com/plataformatec/devise/wiki/How-To:-Redirect-back-to-current-page-after-sign-in,-sign-out,-sign-up,-update)
- [Rails で認証後にセッションIDをリセットする](http://qiita.com/dany1468/items/692fc51d2be58ddb857a)

# 再現・確認手順
- ログイン前に適当なページにアクセスしてみる（ログインページにリダイレクトされる）
- ログイン後、上でアクセスしたページに飛ぶことを確認

# 対応Issue（任意）
https://github.com/hr-dash/hr-dash/issues/372

# ToDo

- [x] ラベル付け
- [x] Assigneesで自分を選択
