### PR TITLE
運営側からのお知らせ

### DIFF
--- a/app/admin/announcement.rb
+++ b/app/admin/announcement.rb
@@ -1,0 +1,24 @@
+ActiveAdmin.register Announcement do
+  active_admin_action_log
+  permit_params { Announcement.column_names }
+
+  index do
+    id_column
+    column :title
+    column :body do |announcement|
+      div { truncate(announcement.body, length: 15) }
+    end
+    column :published_date
+    actions
+  end
+
+  form do |f|
+    f.semantic_errors
+    f.inputs do
+      f.input :title
+      f.input :body
+      f.input :published_date, as: :datepicker
+    end
+    f.actions
+  end
+end

--- a/app/assets/javascripts/announcement.js.coffee
+++ b/app/assets/javascripts/announcement.js.coffee
@@ -1,0 +1,4 @@
+$ ->
+  $('.announcement-link').on 'click', ->
+    id = $(this).attr('data-target')
+    $('#' + id).modal()

--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -1,0 +1,5 @@
+class AnnouncementsController < ApplicationController
+  def index
+    @announcements = Announcement.published.ransack.result.page params[:page]
+  end
+end

--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -1,5 +1,5 @@
 class AnnouncementsController < ApplicationController
   def index
-    @announcements = Announcement.published.ransack.result.page params[:page]
+    @announcements = Announcement.published.page params[:page]
   end
 end

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -1,0 +1,7 @@
+class RootController < ApplicationController
+  def index
+    references = [{ user: :groups }, :monthly_working_process, { monthly_report_tags: :tag }]
+    @monthly_reports = MonthlyReport.includes(references).released.order('shipped_at desc').first(5)
+    @announcements = Announcement.published.first(5)
+  end
+end

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -14,4 +14,8 @@ class Announcement < ActiveRecord::Base
   validates :title, presence: true
   validates :body, presence: true
   validates :published_date, presence: true
+
+  def self.published
+    where('published_date <= ?', Time.current.to_date).order('published_date desc')
+  end
 end

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -1,0 +1,17 @@
+# == Schema Information
+#
+# Table name: announcements
+#
+#  id             :integer          not null, primary key
+#  title          :string           not null
+#  body           :text             not null
+#  published_date :date             not null
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#
+
+class Announcement < ActiveRecord::Base
+  validates :title, presence: true
+  validates :body, presence: true
+  validates :published_date, presence: true
+end

--- a/app/views/announcements/index.html.slim
+++ b/app/views/announcements/index.html.slim
@@ -1,0 +1,7 @@
+- provide :page_title, "お知らせ"
+
+.page-content
+  #announcement_index
+    == render partial: 'layouts/announcement_index', locals: { announcements: @announcements }
+  = paginate @announcements
+

--- a/app/views/layouts/_announcement_index.html.slim
+++ b/app/views/layouts/_announcement_index.html.slim
@@ -1,0 +1,20 @@
+.list-group
+  - announcements.each do |announcement|
+    - id = "announcement_#{announcement.id}"
+    - date = announcement.published_date
+    - date_str = date.strftime('%Y/%m/%d')
+    a.list-group-item.announcement-link data-target=(id)
+      = "#{date_str}　#{announcement.title}"
+      - if date > Time.current.to_date.ago(7.days)
+        span.label.label-primary.right New
+    .modal.fade id=(id)
+      .modal-dialog
+        .modal-content
+          .modal-header
+            h3 = announcement.title
+          .modal-body
+            == render partial: 'layouts/markdown_view', locals: { content: announcement.body }
+          .modal-footer
+            span.left = "#{date_str} に公開"
+            button.btn.btn-default type="button" data-dismiss="modal" 閉じる
+

--- a/app/views/layouts/_report_index.html.slim
+++ b/app/views/layouts/_report_index.html.slim
@@ -1,5 +1,5 @@
 .list-group
-  - @monthly_reports.each do |report|
+  - monthly_reports.each do |report|
     a.list-group-item href=(monthly_report_path(report))
       = report.user.groups.map { |g| "【#{g.name}G】" }.join
       = "#{report.user.name} - #{report.target_month.strftime("%Y年%m月")}分"

--- a/app/views/layouts/_site_header.html.slim
+++ b/app/views/layouts/_site_header.html.slim
@@ -10,7 +10,7 @@ header.site-header.bg-primary.col-xs-2
           span  月報
         ul.dropdown-menu
           li
-            = link_to "Top", monthly_reports_path
+            = link_to "トップ", monthly_reports_path
           li
             = link_to "マイ月報", user_monthly_reports_path(current_user)
           li
@@ -25,7 +25,7 @@ header.site-header.bg-primary.col-xs-2
           span  グループ
         ul.dropdown-menu
           li
-            = link_to "Top", groups_path
+            = link_to "トップ", groups_path
     ul.nav.nav-pills.nav-stacked.header-menu-bottom.dropup
         li.dropdown
           a.lead.bg-primary.dropdown-toggle data-toggle="dropdown" aria-expanded="false"

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -4,8 +4,10 @@ body
     .site-container.row
       = render partial: 'layouts/site_header'
       .col-xs-8.col-xs-offset-3
-        .page-header
-          h1 = yield(:page_title)
+        - title = yield(:page_title)
+        - if title.present?
+          .page-header
+            h1 = title
         .page-body
           = render partial: 'layouts/flash_messages', flash: flash
           = render partial: 'layouts/new_inquiry'

--- a/app/views/monthly_reports/index.html.slim
+++ b/app/views/monthly_reports/index.html.slim
@@ -32,5 +32,5 @@
 .page-content
   h3 = @q.conditions.empty? ? '最新の月報一覧' : '検索結果'
   #report_index
-    == render partial: 'layouts/report_index'
+    == render partial: 'layouts/report_index', locals: { monthly_reports: @monthly_reports }
   = paginate @monthly_reports

--- a/app/views/root/index.html.slim
+++ b/app/views/root/index.html.slim
@@ -1,0 +1,11 @@
+.page-content.clearfix
+  h3 お知らせ
+  #announcement_index
+    == render partial: 'layouts/announcement_index', locals: { announcements: @announcements }
+    = link_to 'お知らせ一覧はこちら', announcements_path, class: 'right'
+
+.page-content.clearfix
+  h3 最近投稿された月報
+  #report_index
+    == render partial: 'layouts/report_index', locals: { monthly_reports: @monthly_reports }
+    = link_to '月報一覧はこちら', monthly_reports_path, class: 'right'

--- a/config/locales/activerecord.ja.yml
+++ b/config/locales/activerecord.ja.yml
@@ -1,6 +1,7 @@
 ja:
   activerecord: &activerecord
     models:
+      announcement: お知らせ
       group: グループ
       group_assignment: グループ割当
       help_text: ヘルプテキスト
@@ -14,6 +15,10 @@ ja:
       user: ユーザー
       user_profile: プロフィール
     attributes:
+      announcement:
+        title: タイトル
+        body: 本文
+        published_date: 公開日
       group:
         name: 名前
         email: メールアドレス

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,7 @@ Rails.application.routes.draw do
 
   root to: 'monthly_reports#index', constraints: Constraints::PageCount
 
+  resources :announcements, only: [:index]
   resources :user_profiles, only: [:show, :edit, :update]
   resources 'monthly_reports', except: :destroy, constraints: Constraints::PageCount do
     collection do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,7 +23,7 @@ Rails.application.routes.draw do
   resources :groups, only: [:index]
   resources :monthly_report_comments, only: [:create, :edit, :update, :destroy]
 
-  root to: 'monthly_reports#index', constraints: Constraints::PageCount
+  root to: 'root#index'
 
   resources :announcements, only: [:index]
   resources :user_profiles, only: [:show, :edit, :update]

--- a/db/migrate/20161224000946_create_announcements.rb
+++ b/db/migrate/20161224000946_create_announcements.rb
@@ -1,0 +1,11 @@
+class CreateAnnouncements < ActiveRecord::Migration
+  def change
+    create_table :announcements do |t|
+      t.string :title, null: false
+      t.text :body, null: false
+      t.date :published_date, null: false
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161028173116) do
+ActiveRecord::Schema.define(version: 20161224000946) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,6 +44,14 @@ ActiveRecord::Schema.define(version: 20161028173116) do
   add_index "active_admin_comments", ["author_type", "author_id"], name: "index_active_admin_comments_on_author_type_and_author_id", using: :btree
   add_index "active_admin_comments", ["namespace"], name: "index_active_admin_comments_on_namespace", using: :btree
   add_index "active_admin_comments", ["resource_type", "resource_id"], name: "index_active_admin_comments_on_resource_type_and_resource_id", using: :btree
+
+  create_table "announcements", force: :cascade do |t|
+    t.string   "title",          null: false
+    t.text     "body",           null: false
+    t.date     "published_date", null: false
+    t.datetime "created_at",     null: false
+    t.datetime "updated_at",     null: false
+  end
 
   create_table "group_assignments", force: :cascade do |t|
     t.integer  "group_id",   null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,6 +5,7 @@
   MonthlyReport,
   Tag,
   HelpText,
+  Announcement,
 ].map(&:destroy_all)
 
 Dir.glob("#{Rails.root}/db/seeds/*.yml").each do |yaml_filename|
@@ -22,6 +23,7 @@ if Rails.env.development?
   FactoryGirl.create(:user, email: 'testuser@example.com', password: 'Passw0rd')
 
   5.times { FactoryGirl.create(:monthly_report, :shipped, :with_tags, :with_comments) }
+  10.times { |i| FactoryGirl.create(:announcement, published_date: Time.current.ago(i.days)) }
 else
   user = User.create(name: 'admin',
                      email: 'test@example.com',

--- a/spec/factories/announcements.rb
+++ b/spec/factories/announcements.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :announcement do
+    title { Faker::Lorem.sentence }
+    body { Faker::Lorem.paragraph }
+    published_date { Time.current.to_date }
+  end
+end

--- a/spec/features/announcement_spec.rb
+++ b/spec/features/announcement_spec.rb
@@ -1,0 +1,22 @@
+describe AnnouncementsController, type: :feature do
+  before { login }
+
+  describe '#index GET /announcements' do
+    let!(:announcement) { create(:announcement) }
+    let(:list) { page.find('#announcement_index') }
+
+    before { visit announcements_path }
+
+    it { expect(list.find('a')).to have_content(announcement.title) }
+
+    describe 'modal', js: true do
+      before do
+        page.execute_script %{ $("#announcement_#{announcement.id}").modal() }
+      end
+
+      let(:modal) { page.find('.modal.fade.in > .modal-dialog') }
+
+      it { expect(modal).to have_content(announcement.title) }
+    end
+  end
+end

--- a/spec/features/root_spec.rb
+++ b/spec/features/root_spec.rb
@@ -1,0 +1,12 @@
+describe RootController, type: :feature do
+  before { login }
+
+  describe '#index GET /' do
+    before { visit root_path }
+    let(:page_contents) { page.all('.page-content') }
+
+    it { expect(current_path).to eq root_path }
+    it { expect(page_contents.first).to have_content('お知らせ') }
+    it { expect(page_contents.last).to have_content('最近投稿された月報') }
+  end
+end

--- a/spec/models/announcement_spec.rb
+++ b/spec/models/announcement_spec.rb
@@ -1,0 +1,22 @@
+# == Schema Information
+#
+# Table name: announcements
+#
+#  id             :integer          not null, primary key
+#  title          :string           not null
+#  body           :text             not null
+#  published_date :date             not null
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#
+
+describe Announcement, type: :model do
+  describe 'Validations' do
+    subject { build(:announcement) }
+
+    it { is_expected.to be_valid }
+    it { is_expected.to validate_presence_of(:title) }
+    it { is_expected.to validate_presence_of(:body) }
+    it { is_expected.to validate_presence_of(:published_date) }
+  end
+end

--- a/spec/models/announcement_spec.rb
+++ b/spec/models/announcement_spec.rb
@@ -19,4 +19,17 @@ describe Announcement, type: :model do
     it { is_expected.to validate_presence_of(:body) }
     it { is_expected.to validate_presence_of(:published_date) }
   end
+
+  describe '.published' do
+    let(:date) { Time.current.to_date }
+    let!(:today) { create(:announcement, published_date: date) }
+    let!(:yesterday) { create(:announcement, published_date: date.yesterday) }
+    let!(:tomorrow) { create(:announcement, published_date: date.tomorrow) }
+
+    subject { described_class.published }
+
+    it { expect(subject.size).to eq 2 }
+    it { expect(subject.first).to eq today }
+    it { expect(subject).not_to include(tomorrow) }
+  end
 end

--- a/spec/requests/monthly_report_spec.rb
+++ b/spec/requests/monthly_report_spec.rb
@@ -10,12 +10,6 @@ describe MonthlyReportsController, type: :request do
     it { expect(response.body).to match report.user.name }
   end
 
-  describe 'root_path' do
-    before { get root_path }
-    it { expect(response).to have_http_status :success }
-    it { expect(response).to render_template('monthly_reports/index') }
-  end
-
   describe '#user GET /monthly_reports/users/:user_id' do
     context 'view my_reports' do
       before { get user_monthly_reports_path(user) }

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -16,7 +16,7 @@ module RequestHelpers
 
   # see: http://qiita.com/saboyutaka/items/cafc2b69ae52f605c8fd
   def wait_for_ajax
-    Timeout.timeout(Capybara.default_wait_time) do
+    Timeout.timeout(Capybara.default_max_wait_time) do
       loop until finished_all_ajax_requests?
     end
   end


### PR DESCRIPTION
# 概要
運営側からのお知らせをTOPに表示する
TOPだけでなく、お知らせの一覧が見れるページも用意した。

# 再現・確認手順
- TOP
- TOPの「お知らせ一覧はこちら」の飛び先

# 対応Issue（任意）
https://github.com/hr-dash/hr-dash/issues/379

# ToDo

- [x] ラベル付け
- [x] Assigneesで自分を選択
