### PR TITLE
月報のグループ検索で、削除済のグループは選択肢に表示しない

### DIFF
--- a/app/views/monthly_reports/index.html.slim
+++ b/app/views/monthly_reports/index.html.slim
@@ -8,7 +8,7 @@
         .form-group
           = f.label :user_groups_id_eq, 'グループ', class: 'control-label col-xs-2'
           .col-xs-10
-            = f.select :user_groups_id_eq, options_for_select(Group.pluck(:name, :id), selected: @q.user_groups_id_eq), { include_blank: true }, class: 'form-control'
+            = f.select :user_groups_id_eq, options_for_select(Group.active.pluck(:name, :id), selected: @q.user_groups_id_eq), { include_blank: true }, class: 'form-control'
         .form-group
           = f.label :user_name_cont, '氏名', class: 'control-label col-xs-2'
           .col-xs-10


### PR DESCRIPTION
# 概要
タイトル通り

# 再現・確認手順
グループを削除（日付は昨日以前）にして、月報検索のセレクトボックスから除外されているかを確認

# 対応Issue（任意）
https://github.com/hr-dash/hr-dash/issues/386

# ToDo

- [x] ラベル付け
- [x] Assigneesで自分を選択
