### PR TITLE
Dev/396 no send

### DIFF
--- a/app/mailers/mailer/notify.rb
+++ b/app/mailers/mailer/notify.rb
@@ -3,7 +3,7 @@ module Mailer
     def monthly_report_registration(user_id, monthly_report_id)
       @report = MonthlyReport.find(monthly_report_id)
       @user = User.find(user_id)
-      return unless @user.groups
+      return unless @user.groups.present?
 
       @title = "#{@user.name}が#{@report.target_month.strftime('%Y年%m月')}の月報を登録しました"
       mail(to: @user.groups.map(&:email), subject: @title)

--- a/spec/mailers/notify_spec.rb
+++ b/spec/mailers/notify_spec.rb
@@ -22,5 +22,10 @@ RSpec.describe Mailer::Notify, type: :mailer do
     it { expect(mail_body).to match(user.name) }
     it { expect(mail_body).to match("#{target_at}の業務報告") }
     it { expect(mail_body).to match("#{monthly_report_path(report)}") }
+
+    context 'if user does not belong to group' do
+      let(:user) { create(:user, group_size: 0) }
+      it { expect { mail.deliver_now }.not_to change { ActionMailer::Base.deliveries.count } }
+    end
   end
 end


### PR DESCRIPTION
# 概要
月報登録時、グループ未所属の場合にも通知メールが送信されてしまう
グループの存在チェックが甘かった

# 再現・確認手順
グループ未所属のユーザーで月報登録してみる

# 対応Issue（任意）
https://github.com/hr-dash/hr-dash/issues/396

# ToDo

- [x] ラベル付け
- [x] Assigneesで自分を選択
