### PR TITLE
Dev/345 modify dashboard

### DIFF
--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -1,5 +1,6 @@
 ActiveAdmin.register_page 'Dashboard' do
   DISPLAY_MONTHLY_REPORT_LIMIT = 10
+  DISPLAY_UNFIXED_TAG_LIMIT = 10
 
   menu priority: 1, label: proc { I18n.t('active_admin.dashboard') }
 
@@ -28,7 +29,7 @@ ActiveAdmin.register_page 'Dashboard' do
     columns do
       column do
         panel '未登録タグ', id: :unfixed_tags do
-          unfixed_tags = Tag.unfixed.order(created_at: :desc)
+          unfixed_tags = Tag.unfixed.order(created_at: :desc).limit(DISPLAY_UNFIXED_TAG_LIMIT)
           if unfixed_tags.present?
             table_for unfixed_tags do
               column(:name) { |t| link_to(t.name, admin_tag_path(t)) }

--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -2,31 +2,19 @@ ActiveAdmin.register_page 'Dashboard' do
   menu priority: 1, label: proc { I18n.t('active_admin.dashboard') }
 
   content title: proc { I18n.t('active_admin.dashboard') } do
-    div class: 'blank_slate_container', id: 'dashboard_default_message' do
-      span class: 'blank_slate' do
-        span I18n.t('active_admin.dashboard_welcome.welcome')
-        small I18n.t('active_admin.dashboard_welcome.call_to_action')
+    columns do
+      column do
+        panel '未登録タグ', id: :unfixed_tags do
+          unfixed_tags = Tag.unfixed
+          if unfixed_tags.present?
+            table_for(unfixed_tags.order(created_at: :desc)) do
+              column(:name) { |t| link_to(t.name, admin_tag_path(t)) }
+            end
+          else
+            para '未登録のタグはありません'
+          end
+        end
       end
     end
-
-    # Here is an example of a simple dashboard with columns and panels.
-    #
-    # columns do
-    #   column do
-    #     panel "Recent Posts" do
-    #       ul do
-    #         Post.recent(5).map do |post|
-    #           li link_to(post.title, admin_post_path(post))
-    #         end
-    #       end
-    #     end
-    #   end
-
-    #   column do
-    #     panel "Info" do
-    #       para "Welcome to ActiveAdmin."
-    #     end
-    #   end
-    # end
   end # content
 end

--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -1,13 +1,36 @@
 ActiveAdmin.register_page 'Dashboard' do
+  DISPLAY_MONTHLY_REPORT_LIMIT = 10
+
   menu priority: 1, label: proc { I18n.t('active_admin.dashboard') }
 
   content title: proc { I18n.t('active_admin.dashboard') } do
     columns do
+      Group.active.each do |group|
+        column max_width: '45%', min_width: '45%' do
+          panel "最新の月報 【#{group.name}グループ】" do
+            reports = MonthlyReport
+              .includes(:user)
+              .where(user_id: group.users)
+              .order(created_at: :desc)
+              .limit(DISPLAY_MONTHLY_REPORT_LIMIT)
+
+            table_for reports do
+              column(:id) { |r| link_to(r.id, admin_monthly_report_path(r)) }
+              column(:user)
+              column(:target_month) { |r| r.target_month.strftime('%Y年%m月') }
+              column(:shipped_at) { |r| r.shipped_at.to_s }
+            end
+          end
+        end
+      end
+    end
+
+    columns do
       column do
         panel '未登録タグ', id: :unfixed_tags do
-          unfixed_tags = Tag.unfixed
+          unfixed_tags = Tag.unfixed.order(created_at: :desc)
           if unfixed_tags.present?
-            table_for(unfixed_tags.order(created_at: :desc)) do
+            table_for unfixed_tags do
               column(:name) { |t| link_to(t.name, admin_tag_path(t)) }
             end
           else
@@ -16,5 +39,5 @@ ActiveAdmin.register_page 'Dashboard' do
         end
       end
     end
-  end # content
+  end
 end

--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -9,10 +9,10 @@ ActiveAdmin.register_page 'Dashboard' do
         column max_width: '45%', min_width: '45%' do
           panel "最新の月報 【#{group.name}グループ】" do
             reports = MonthlyReport
-              .includes(:user)
-              .where(user_id: group.users)
-              .order(created_at: :desc)
-              .limit(DISPLAY_MONTHLY_REPORT_LIMIT)
+                      .includes(:user)
+                      .where(user_id: group.users)
+                      .order(created_at: :desc)
+                      .limit(DISPLAY_MONTHLY_REPORT_LIMIT)
 
             table_for reports do
               column(:id) { |r| link_to(r.id, admin_monthly_report_path(r)) }

--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -28,7 +28,7 @@ ActiveAdmin.register_page 'Dashboard' do
 
     columns do
       column do
-        panel '未登録タグ', id: :unfixed_tags do
+        panel '最新の未登録タグ', id: :unfixed_tags do
           unfixed_tags = Tag.unfixed.order(created_at: :desc).limit(DISPLAY_UNFIXED_TAG_LIMIT)
           if unfixed_tags.present?
             table_for unfixed_tags do

--- a/spec/features/admin/dashboard_spec.rb
+++ b/spec/features/admin/dashboard_spec.rb
@@ -4,10 +4,13 @@ describe 'Admin::Dashboard', type: :feature do
   end
 
   describe '#index GET /admin' do
-    before { visit admin_root_path }
-    let(:title) { find('#page_title') }
-    it { expect(title).to have_content('ダッシュボード') }
-    it { expect(page).to have_content('未登録タグ') }
+    context 'visit dashboard' do
+      let(:title) { find('#page_title') }
+      before { visit admin_root_path }
+      it { expect(title).to have_content('ダッシュボード') }
+      it { expect(page).to have_content('最新の月報') }
+      it { expect(page).to have_content('未登録タグ') }
+    end
 
     context 'monthly_reports' do
       let!(:report) { create(:monthly_report) }

--- a/spec/features/admin/dashboard_spec.rb
+++ b/spec/features/admin/dashboard_spec.rb
@@ -9,6 +9,16 @@ describe 'Admin::Dashboard', type: :feature do
     it { expect(title).to have_content('ダッシュボード') }
     it { expect(page).to have_content('未登録タグ') }
 
+    context 'monthly_reports' do
+      let!(:report) { create(:monthly_report) }
+      let(:target_month) { report.target_month.strftime('%Y年%m月') }
+      before { visit admin_root_path }
+      it { expect(page).to have_content(report.id) }
+      it { expect(page).to have_content(report.user.name) }
+      it { expect(page).to have_content(target_month) }
+      it { expect(page).to have_content(report.shipped_at.to_s) }
+    end
+
     context 'unfixed tag' do
       let!(:tag) { create(:tag, :unfixed) }
       before { visit admin_root_path }

--- a/spec/features/admin/dashboard_spec.rb
+++ b/spec/features/admin/dashboard_spec.rb
@@ -9,7 +9,7 @@ describe 'Admin::Dashboard', type: :feature do
       before { visit admin_root_path }
       it { expect(title).to have_content('ダッシュボード') }
       it { expect(page).to have_content('最新の月報') }
-      it { expect(page).to have_content('未登録タグ') }
+      it { expect(page).to have_content('最新の未登録タグ') }
     end
 
     context 'monthly_reports' do

--- a/spec/features/admin/dashboard_spec.rb
+++ b/spec/features/admin/dashboard_spec.rb
@@ -7,5 +7,19 @@ describe 'Admin::Dashboard', type: :feature do
     before { visit admin_root_path }
     let(:title) { find('#page_title') }
     it { expect(title).to have_content('ダッシュボード') }
+    it { expect(page).to have_content('未登録タグ') }
+
+    context 'unfixed tag' do
+      let!(:tag) { create(:tag, :unfixed) }
+      before { visit admin_root_path }
+      it { expect(page).to have_content(tag.name) }
+    end
+
+    context 'fixed tag' do
+      let!(:tag) { create(:tag, :fixed) }
+      before { visit admin_root_path }
+      it { expect(page).not_to have_content(tag.name) }
+      it { expect(page).to have_content('未登録のタグはありません') }
+    end
   end
 end


### PR DESCRIPTION
# 概要
dashboardに
- グループ別の最新月報（とりあえず各グループ10件）
- 未登録タグ全件

# 再現・確認手順
adminアカウントでログインして `/admin` へ

# 対応Issue（任意）
#345

# ToDo

- [x] ラベル付け
- [x] Assigneesで自分を選択
