### PR TITLE
送信されてくるメールにフッターを付ける

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,2 +1,3 @@
 class ApplicationMailer < ActionMailer::Base
+  layout 'mailer'
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,3 +1,7 @@
 class ApplicationMailer < ActionMailer::Base
   layout 'mailer'
+
+  def mail_subject(title)
+    "【Dash】#{title}"
+  end
 end

--- a/app/mailers/mailer/error.rb
+++ b/app/mailers/mailer/error.rb
@@ -6,7 +6,7 @@ module Mailer
       @request = request
 
       @title = "#{exception.class} が発生しました"
-      mail(to: ENV['SYSTEM_MAIL'], subject: @title)
+      mail(to: ENV['SYSTEM_MAIL'], subject: mail_subject(@title))
     end
   end
 end

--- a/app/mailers/mailer/inquiry.rb
+++ b/app/mailers/mailer/inquiry.rb
@@ -5,7 +5,7 @@ module Mailer
       user = inquiry.user
       @title = "#{user.name}（USER_ID: #{user.id}）さんからお問い合わせが届きました"
 
-      mail(to: ENV['SYSTEM_MAIL'], subject: @title)
+      mail(to: ENV['SYSTEM_MAIL'], subject: mail_subject(@title))
     end
   end
 end

--- a/app/mailers/mailer/notify.rb
+++ b/app/mailers/mailer/notify.rb
@@ -6,7 +6,7 @@ module Mailer
       return unless @user.groups.present?
 
       @title = "#{@user.name}が#{@report.target_month.strftime('%Y年%m月')}の月報を登録しました"
-      mail(to: @user.groups.map(&:email), subject: @title)
+      mail(to: @user.groups.map(&:email), subject: mail_subject(@title))
     end
   end
 end

--- a/app/views/devise/mailer/reset_password_instructions.html.slim
+++ b/app/views/devise/mailer/reset_password_instructions.html.slim
@@ -1,8 +1,0 @@
-p = @resource.name + "さん"
-
-p = "email: #{@resource.email} 宛にパスワードの再設定がリクエストされました。"
-p 以下のリンクから再設定が可能です。
-p = link_to 'パスワード再設定用URL', edit_password_reset_url(@resource, reset_password_token: @token)
-
-p このメールに心当たりが無い場合は無視してください。
-p 上記URLを通して再設定しない限り、パスワードは変更されません。

--- a/app/views/devise/mailer/reset_password_instructions.text.erb
+++ b/app/views/devise/mailer/reset_password_instructions.text.erb
@@ -1,0 +1,11 @@
+<%= @resource.name %> さん
+
+email: <%= @resource.email %> 宛にパスワードの再設定がリクエストされました。
+
+以下のリンクから再設定が可能です。
+<%= edit_password_reset_url(@resource, reset_password_token: @token) %>
+
+このメールに心当たりが無い場合は無視してください。
+上記URLを通して再設定しない限り、パスワードは変更されません。
+
+<%== render 'mailer/footer' %>

--- a/app/views/layouts/mailer.text.erb
+++ b/app/views/layouts/mailer.text.erb
@@ -1,0 +1,3 @@
+<%== yield %>
+
+<%== render 'mailer/footer' %>

--- a/app/views/mailer/_footer.text.erb
+++ b/app/views/mailer/_footer.text.erb
@@ -1,0 +1,7 @@
+
+-----------------
+Dash（月報システム）
+
+URL: <%= root_url %>
+E-mail: <%= ENV['SYSTEM_MAIL'] %>
+

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,5 @@
+ja:
+  devise:
+    mailer:
+      reset_password_instructions:
+        subject: "【Dash】パスワードの再設定について"

--- a/spec/mailers/notify_spec.rb
+++ b/spec/mailers/notify_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Mailer::Notify, type: :mailer do
     let(:mail) { Mailer::Notify.monthly_report_registration(user.id, report.id) }
     let(:name) { user.name }
     let(:target_at) { report.target_month.strftime('%Y年%m月') }
-    let(:title) { "#{name}が#{target_at}の月報を登録しました" }
+    let(:title) { "【Dash】#{name}が#{target_at}の月報を登録しました" }
     let(:mail_body) { mail.body.raw_source }
     it { expect { mail.deliver_now }.to change { ActionMailer::Base.deliveries.count }.from(0).to(1) }
     it { expect(mail.subject).to eq(title) }

--- a/spec/mailers/notify_spec.rb
+++ b/spec/mailers/notify_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe Mailer::Notify, type: :mailer do
     it { expect(mail_body).to match(user.name) }
     it { expect(mail_body).to match("#{target_at}の業務報告") }
     it { expect(mail_body).to match("#{monthly_report_path(report)}") }
+    it { expect(mail_body).to match('Dash') }
 
     context 'if user does not belong to group' do
       let(:user) { create(:user, group_size: 0) }


### PR DESCRIPTION
# 概要
メールに

- 共通フッター
- 件名のPrefix

を追加した

# 再現・確認手順
メールを送る処理をしてみる

# 対応Issue（任意）
https://github.com/hr-dash/hr-dash/issues/368

# ToDo

- [x] ラベル付け
- [x] Assigneesで自分を選択
