### PR TITLE
月報のコメント数を表示する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem 'enum_help'
 gem 'activeadmin', github: 'activeadmin'
 gem 'active_admin_import', github: "activeadmin-plugins/active_admin_import"
 gem 'aws-sdk-rails'
+gem 'counter_culture', '~> 1.0'
 gem 'slim'
 gem 'slim-rails'
 gem 'kaminari'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,6 +69,9 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.4.0)
+    after_commit_action (1.0.1)
+      activerecord (>= 3.0.0)
+      activesupport (>= 3.0.0)
     airbrussh (1.0.2)
       sshkit (>= 1.6.1, != 1.7.0)
     annotate (2.6.10)
@@ -161,6 +164,10 @@ GEM
     concurrent-ruby (1.0.2)
     concurrent-ruby-ext (1.0.2)
       concurrent-ruby (~> 1.0.2)
+    counter_culture (1.1.0)
+      activerecord (>= 3.0.0)
+      activesupport (>= 3.0.0)
+      after_commit_action (~> 1.0)
     database_rewinder (0.5.3)
     debug_inspector (0.0.2)
     debugger-ruby_core_source (1.3.8)
@@ -451,6 +458,7 @@ DEPENDENCIES
   capistrano3-nginx
   capistrano3-unicorn
   coffee-rails (~> 4.1.0)
+  counter_culture (~> 1.0)
   database_rewinder
   devise
   devise-i18n

--- a/app/assets/stylesheets/style.css.scss
+++ b/app/assets/stylesheets/style.css.scss
@@ -79,3 +79,22 @@ html, body, .site-body, .site-container, .site-header, .header-menu {
 .alert {
   margin-bottom: 10px;
 }
+
+/* monthly-report-index */
+.monthly-report-index {
+  .pull-right {
+    .tag {
+      margin-left: 0.5em;
+    }
+
+    .comments_count {
+      display: inline-block;
+      width: 3.5em;
+      padding-left: 1em;
+
+      .glyphicon {
+        margin-right: 0.3em;
+      }
+    }
+  }
+}

--- a/app/models/monthly_report.rb
+++ b/app/models/monthly_report.rb
@@ -12,6 +12,7 @@
 #  next_month_goals :text
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
+#  comments_count   :integer          default(0), not null
 #
 
 class MonthlyReport < ActiveRecord::Base

--- a/app/models/monthly_report_comment.rb
+++ b/app/models/monthly_report_comment.rb
@@ -13,6 +13,7 @@
 class MonthlyReportComment < ActiveRecord::Base
   belongs_to :user
   belongs_to :monthly_report
+  counter_culture :monthly_report, column_name: 'comments_count'
 
   validates :user, presence: true
   validates :monthly_report, presence: true

--- a/app/views/layouts/_report_index.html.slim
+++ b/app/views/layouts/_report_index.html.slim
@@ -1,8 +1,12 @@
-.list-group
+.list-group.monthly-report-index
   - monthly_reports.each do |report|
     a.list-group-item href=(monthly_report_path(report))
       = report.user.groups.map { |g| "【#{g.name}G】" }.join
       = "#{report.user.name} - #{report.target_month.strftime("%Y年%m月")}分"
       - tags = report.monthly_report_tags.order('monthly_report_tags.id')
-      - tags.first(3).each do |tag|
-        span.badge = tag.name
+      .pull-right
+        - tags.first(3).each do |tag|
+          span.tag.label.label-success = "#{tag.name} "
+        span.comments_count
+          span.glyphicon.glyphicon-comment aria-hidden="true"
+          span = report.comments_count

--- a/db/migrate/20170107145744_add_comments_count_to_monthly_reports.rb
+++ b/db/migrate/20170107145744_add_comments_count_to_monthly_reports.rb
@@ -1,0 +1,9 @@
+class AddCommentsCountToMonthlyReports < ActiveRecord::Migration
+  def self.up
+    add_column :monthly_reports, :comments_count, :integer, null: false, default: 0
+  end
+
+  def self.down
+    remove_column :monthly_reports, :comments_count
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161224000946) do
+ActiveRecord::Schema.define(version: 20170107145744) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -112,15 +112,16 @@ ActiveRecord::Schema.define(version: 20161224000946) do
   end
 
   create_table "monthly_reports", force: :cascade do |t|
-    t.integer  "user_id",          null: false
-    t.date     "target_month",     null: false
+    t.integer  "user_id",                      null: false
+    t.date     "target_month",                 null: false
     t.datetime "shipped_at"
     t.text     "project_summary"
     t.text     "business_content"
     t.text     "looking_back"
     t.text     "next_month_goals"
-    t.datetime "created_at",       null: false
-    t.datetime "updated_at",       null: false
+    t.datetime "created_at",                   null: false
+    t.datetime "updated_at",                   null: false
+    t.integer  "comments_count",   default: 0, null: false
   end
 
   add_index "monthly_reports", ["target_month"], name: "index_monthly_reports_on_target_month", using: :btree

--- a/lib/tasks/comments_counter.rake
+++ b/lib/tasks/comments_counter.rake
@@ -1,0 +1,8 @@
+namespace :comments_counter do
+  desc 'Calculate monthly_report_comments count'
+  task calculate: :environment do
+    MonthlyReport.all.each do |report|
+      report.update(comments_count: report.comments.count)
+    end
+  end
+end

--- a/spec/factories/announcements.rb
+++ b/spec/factories/announcements.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: announcements
+#
+#  id             :integer          not null, primary key
+#  title          :string           not null
+#  body           :text             not null
+#  published_date :date             not null
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#
+
 FactoryGirl.define do
   factory :announcement do
     title { Faker::Lorem.sentence }

--- a/spec/factories/group_assignments.rb
+++ b/spec/factories/group_assignments.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: group_assignments
+#
+#  id         :integer          not null, primary key
+#  group_id   :integer          not null
+#  user_id    :integer          not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
 FactoryGirl.define do
   factory :group_assignment do
     association :group

--- a/spec/factories/inquiries.rb
+++ b/spec/factories/inquiries.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: inquiries
+#
+#  id         :integer          not null, primary key
+#  user_id    :integer          not null
+#  body       :text             not null
+#  referer    :string
+#  user_agent :string
+#  session_id :string
+#  admin_memo :text
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
 FactoryGirl.define do
   factory :inquiry do
     association :user

--- a/spec/models/monthly_report_spec.rb
+++ b/spec/models/monthly_report_spec.rb
@@ -12,6 +12,7 @@
 #  next_month_goals :text
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
+#  comments_count   :integer          default(0), not null
 #
 
 RSpec.describe MonthlyReport, type: :model do

--- a/spec/tasks/comments_counter_spec.rb
+++ b/spec/tasks/comments_counter_spec.rb
@@ -1,0 +1,14 @@
+describe 'comments_counter' do
+  let(:report) { create(:monthly_report, :with_comments, comment_size: comment_size) }
+  let(:comment_size) { Faker::Number.between(1, 10) }
+
+  before do
+    # set wrong count
+    report.update(comments_count: 0)
+    Rake::Task['comments_counter:calculate'].invoke
+  end
+
+  describe 'calculate' do
+    it { expect(report.reload.comments_count).to eq comment_size }
+  end
+end


### PR DESCRIPTION
# 概要
一覧画面でコメント数を表示する
[counter_culture](https://github.com/magnusvk/counter_culture) を利用

アップデート時、以下のRakeタスクを叩く必要がある
```
bundle exec rake comments_counter:calculate
```

# 再現・確認手順
コメントを追加／削除してコメント数が増減するか確認

# 対応Issue（任意）
https://github.com/hr-dash/hr-dash/issues/355

# ToDo

- [x] ラベル付け
- [x] Assigneesで自分を選択
