### PR TITLE
breaks オプションを追加

### DIFF
--- a/app/assets/javascripts/markdown-parser.js.coffee
+++ b/app/assets/javascripts/markdown-parser.js.coffee
@@ -2,6 +2,7 @@ $ ->
   marked.setOptions({
     gfm: true,
     sanitize: true,
+    breaks: true,
     highlight: (code) ->
       hljs.highlightAuto(code).value
   })


### PR DESCRIPTION
# 概要
Markdown parse時にbreaks オプションを追加
以前はサーバー側のMarkdownオプションに合わせるため使用していなかったが、統一されたのでフロント側で自由にして良い

# 再現・確認手順
改行すればparse結果も改行される（スペース2個入れなくて良い）

# 対応Issue（任意）

# ToDo

- [x] ラベル付け
- [x] Assigneesで自分を選択
