### PR TITLE
グループ割当て機能を使いやすく

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem 'devise'
 gem 'devise-i18n'
 gem 'enum_help'
 gem 'activeadmin', github: 'activeadmin'
+gem 'activeadmin_addons'
 gem 'active_admin_import', github: "activeadmin-plugins/active_admin_import"
 gem 'aws-sdk-rails'
 gem 'counter_culture', '~> 1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,6 +48,10 @@ GEM
       erubis (~> 2.7.0)
       rails-dom-testing (~> 1.0, >= 1.0.5)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    activeadmin_addons (0.10.1)
+      railties
+      select2-rails (~> 3.5.9)
+      xdan-datetimepicker-rails (~> 2.5.1)
     activejob (4.2.7.1)
       activesupport (= 4.2.7.1)
       globalid (>= 0.3.0)
@@ -375,6 +379,8 @@ GEM
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
+    select2-rails (3.5.10)
+      thor (~> 0.14)
     shoulda-matchers (3.0.1)
       activesupport (>= 4.0.0)
     shoulda-whenever (0.0.2)
@@ -436,6 +442,9 @@ GEM
     websocket-extensions (0.1.2)
     whenever (0.9.7)
       chronic (>= 0.6.3)
+    xdan-datetimepicker-rails (2.5.4)
+      jquery-rails
+      rails (>= 3.2.16)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -445,6 +454,7 @@ PLATFORMS
 DEPENDENCIES
   active_admin_import!
   activeadmin!
+  activeadmin_addons
   activerecord-cause
   annotate
   autodoc
@@ -504,4 +514,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   1.13.6
+   1.13.7

--- a/app/assets/javascripts/admin/active_admin.js.coffee
+++ b/app/assets/javascripts/admin/active_admin.js.coffee
@@ -1,1 +1,2 @@
 #= require active_admin/base
+#= require activeadmin_addons/all

--- a/app/assets/stylesheets/admin/active_admin.scss
+++ b/app/assets/stylesheets/admin/active_admin.scss
@@ -1,3 +1,4 @@
+//= require activeadmin_addons/all
 // SASS variable overrides must be declared before loading up Active Admin's styles.
 //
 // To view the variables that Active Admin provides, take a look at

--- a/app/views/admin/groups/_assign_form.html.erb
+++ b/app/views/admin/groups/_assign_form.html.erb
@@ -1,0 +1,18 @@
+<ol>
+<li>
+  <label for="group_assign_form">
+    グループに割当てるユーザー
+    <br />
+    <% all_users = User.all.map { |user| [user.name, user.id] } %>
+    <%= select_tag 'user_ids[]', options_for_select(all_users, selected: group_users.map(&:id)), multiple: true %>
+  </label>
+</li>
+</ol>
+
+<script>
+$(function() {
+  $('#group_assign_form').select2({
+    placeholder: 'ユーザーを選択'
+  });
+});
+</script>

--- a/app/views/admin/groups/_assign_form.html.erb
+++ b/app/views/admin/groups/_assign_form.html.erb
@@ -4,7 +4,7 @@
     グループに割当てるユーザー
     <br />
     <% all_users = User.all.map { |user| [user.name, user.id] } %>
-    <%= select_tag 'user_ids[]', options_for_select(all_users, selected: group_users.map(&:id)), multiple: true %>
+    <%= select_tag 'user_ids[]', options_for_select(all_users, selected: group_users.map(&:id)), id: :group_assign_form, multiple: true %>
   </label>
 </li>
 </ol>

--- a/app/views/admin/groups/_assign_form.html.erb
+++ b/app/views/admin/groups/_assign_form.html.erb
@@ -3,7 +3,7 @@
   <label for="group_assign_form">
     グループに割当てるユーザー
     <br />
-    <% all_users = User.all.map { |user| [user.name, user.id] } %>
+    <% all_users = User.pluck(:name, :id) %>
     <%= select_tag 'user_ids[]', options_for_select(all_users, selected: group_users.map(&:id)), id: :group_assign_form, multiple: true %>
   </label>
 </li>

--- a/app/views/admin/groups/edit_group_assign.html.slim
+++ b/app/views/admin/groups/edit_group_assign.html.slim
@@ -1,13 +1,8 @@
 = form_tag update_group_assign_admin_group_path(@group), html: { class: 'formastic' } do |f|
   fieldset.inputs
+    - group_users = @group.users
     legend
       span = "#{@group.name} グループの割当を編集"
-    ol
-      li
-        - group_user_ids = @group.users.map(&:id)
-        - User.all.each do |user|
-          = check_box_tag 'user_ids[]', user.id, group_user_ids.include?(user.id), id: "user_id_#{user.id}"
-          span = user.name
-          span = "　"
+    == render 'admin/groups/assign_form', group_users: group_users
   fieldset.actions
     ol = submit_tag '更新する'

--- a/spec/features/admin/group_spec.rb
+++ b/spec/features/admin/group_spec.rb
@@ -47,13 +47,14 @@ describe 'Admin::Group', type: :feature do
     it { expect(group.reload.description).to eq new_description }
   end
 
-  describe '#update_group_assign' do
+  describe '#update_group_assign', js: true do
     let!(:another_user) { create(:user) }
     before do
       visit edit_group_assign_admin_group_path(group)
-      check "user_id_#{another_user.id}"
-      uncheck "user_id_#{user.id}"
-      click_on '更新する'
+      find('#s2id_user_ids_').find('.select2-search-choice-close').click
+      page.execute_script "$('option[value=#{another_user.id}]').attr('selected', true)"
+      find('input[name=commit]').trigger('click')
+      sleep 0.4
     end
 
     it { expect(page_title).to have_content(group.name) }

--- a/spec/features/admin/group_spec.rb
+++ b/spec/features/admin/group_spec.rb
@@ -51,7 +51,7 @@ describe 'Admin::Group', type: :feature do
     let!(:another_user) { create(:user) }
     before do
       visit edit_group_assign_admin_group_path(group)
-      find('#s2id_user_ids_').find('.select2-search-choice-close').click
+      find('#s2id_group_assign_form').find('.select2-search-choice-close').click
       page.execute_script "$('option[value=#{another_user.id}]').attr('selected', true)"
       find('input[name=commit]').trigger('click')
       sleep 0.4


### PR DESCRIPTION
# 概要
管理画面のグループ割当て機能が使いにくかったので、 `activeadmin_addons` を入れて使いやすくした。

# 再現・確認手順
addon を入れたことで管理画面全体に影響しているので、全体的に確認が必要

# 対応Issue（任意）

# ToDo

- [x] ラベル付け
- [x] Assigneesで自分を選択
