### PR TITLE
エラーページをいい感じにする

### DIFF
--- a/app/assets/stylesheets/main/errors.scss
+++ b/app/assets/stylesheets/main/errors.scss
@@ -1,0 +1,29 @@
+.error-container {
+  position: relative;
+  height: 100%;
+  width: 100%;
+
+  .error-body {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    margin: auto;
+    width: 50%;
+    height: 50%;
+
+    h1 {
+      font-size: 12rem;
+    }
+
+    .links {
+      margin-top: 3rem;
+
+      a {
+        text-decoration: none;
+      }
+    }
+  }
+}
+

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -2,14 +2,33 @@ class ErrorsController < ActionController::Base
   layout 'error'
 
   rescue_from StandardError, with: :render_internal_server_error
-  rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
+  rescue_from ActionController::NotImplemented, with: :render_not_implemented
   rescue_from ActionController::RoutingError, with: :render_not_found
+  rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
+  rescue_from ActionController::MethodNotAllowed, with: :render_method_not_allowed
+  rescue_from ActiveRecord::StaleObjectError, with: :render_conflict
+  rescue_from ActiveRecord::RecordInvalid, with: :render_unprocessable_entity
+  rescue_from ActiveRecord::RecordNotSaved, with: :render_unprocessable_entity
+  rescue_from ActionController::InvalidAuthenticityToken, with: :render_unprocessable_entity
 
   def render_not_found(exception = nil)
-    if exception
-      logger.info "Rendering 404 with exception: #{exception.message}"
-    end
+    log_error(exception)
     render template: 'errors/404', status: 404
+  end
+
+  def render_method_not_allowed(exception = nil)
+    log_error(exception)
+    render template: 'errors/405', status: 405
+  end
+
+  def render_conflict(exception = nil)
+    log_error(exception)
+    render template: 'errors/409', status: 409
+  end
+
+  def render_unprocessable_entity(exception = nil)
+    log_error(exception)
+    render template: 'errors/422', status: 422
   end
 
   def render_internal_server_error(exception = nil)
@@ -20,7 +39,22 @@ class ErrorsController < ActionController::Base
     render template: 'errors/500', status: 500
   end
 
+  def render_not_implemented(exception = nil)
+    if exception
+      Mailer::Error.create(exception, current_user, request).deliver_now
+      logger.info "Rendering 501 with exception: #{exception.message}"
+    end
+    render template: 'errors/501', status: 501
+  end
+
   def show
     fail env['action_dispatch.exception']
+  end
+
+  private
+
+  def log_error(exception)
+    return unless exception
+    logger.info "#{exception.class} error has occurred with message: #{exception.message}"
   end
 end

--- a/app/views/errors/404.html.slim
+++ b/app/views/errors/404.html.slim
@@ -1,1 +1,2 @@
-= "Error: 404"
+- provide :error_status, '404'
+- provide :error_message, 'Not Found'

--- a/app/views/errors/405.html.slim
+++ b/app/views/errors/405.html.slim
@@ -1,0 +1,2 @@
+- provide :error_status, '405'
+- provide :error_message, 'Method Not Allowed'

--- a/app/views/errors/409.html.slim
+++ b/app/views/errors/409.html.slim
@@ -1,0 +1,2 @@
+- provide :error_status, '409'
+- provide :error_message, 'Conflict'

--- a/app/views/errors/422.html.slim
+++ b/app/views/errors/422.html.slim
@@ -1,0 +1,2 @@
+- provide :error_status, '422'
+- provide :error_message, 'Unprocessable Entity'

--- a/app/views/errors/500.html.slim
+++ b/app/views/errors/500.html.slim
@@ -1,4 +1,2 @@
-= "Error: 500"
-= render partial: 'layouts/new_inquiry'
-br
-= button_tag 'お問い合わせ', class: 'btn btn-success', 'data-toggle' => 'modal', 'data-target' => '#new_inquiry'
+- provide :error_status, '500'
+- provide :error_message, 'Internal Server Error'

--- a/app/views/errors/501.html.slim
+++ b/app/views/errors/501.html.slim
@@ -1,0 +1,2 @@
+- provide :error_status, '501'
+- provide :error_message, 'Not Implemented'

--- a/app/views/layouts/error.html.slim
+++ b/app/views/layouts/error.html.slim
@@ -1,4 +1,14 @@
 = render partial: 'layouts/html_header'
+- error_status = yield(:error_status)
+- error_message = yield(:error_message)
+
 body
-  h1 Error Page
-  = yield
+  = render partial: 'layouts/new_inquiry'
+  .container-fluid.error-container
+    .error-body
+      h1.text-center = error_status
+      h3.text-center = error_message
+      .links.row
+        .col-xs-offset-2.col-xs-4
+          a href=(root_path) = button_tag 'トップへ戻る', class: 'btn btn-primary center-block'
+        .col-xs-4 = button_tag 'お問い合わせ', class: 'btn btn-success center-block', 'data-toggle' => 'modal', 'data-target' => '#new_inquiry'


### PR DESCRIPTION
# 概要
エラーページをいい感じにする
と同時に、Railsで通常発生し得るいくつかのエラーを拾うよう修正

# 再現・確認手順
`config/environments/development.rb` で
`config.consider_all_requests_local       = false` を指定する

エラーを起こすアクションをしてみる
もしくは、強制的に起こしてみる

適切なエラーページが表示されているかを確認

# 対応Issue（任意）
2件に対応

https://github.com/hr-dash/hr-dash/issues/387
https://github.com/hr-dash/hr-dash/issues/393

# ToDo

- [x] ラベル付け
- [x] Assigneesで自分を選択
