### PR TITLE
add shipped_at to monthly_report/index

### DIFF
--- a/app/assets/stylesheets/main/monthly_reports.scss
+++ b/app/assets/stylesheets/main/monthly_reports.scss
@@ -13,3 +13,7 @@ div.monthly-report-panel-header {
 a#edit-monthly-button {
   margin-left: 5px;
 }
+
+small#monthly-report-shipped-at {
+  padding-left: 10px;
+}

--- a/app/assets/stylesheets/main/monthly_reports.scss
+++ b/app/assets/stylesheets/main/monthly_reports.scss
@@ -14,6 +14,6 @@ a#edit-monthly-button {
   margin-left: 5px;
 }
 
-small#monthly-report-shipped-at {
+small.monthly-report-shipped-at {
   padding-left: 10px;
 }

--- a/app/views/layouts/_report_index.html.slim
+++ b/app/views/layouts/_report_index.html.slim
@@ -3,8 +3,8 @@
     a.list-group-item href=(monthly_report_path(report))
       = report.user.groups.map { |g| "【#{g.name}G】" }.join
       = "#{report.user.name} - #{report.target_month.strftime("%Y年%m月")}分"
-      small#monthly-report-shipped-at.text-muted
-        = "投稿日:#{report.shipped_at.strftime("%Y-%m-%d")}"
+      small.monthly-report-shipped-at.text-muted
+        = "投稿日: #{report.shipped_at.strftime("%Y-%m-%d")}"
       - tags = report.monthly_report_tags.order('monthly_report_tags.id')
       .pull-right
         - tags.first(3).each do |tag|

--- a/app/views/layouts/_report_index.html.slim
+++ b/app/views/layouts/_report_index.html.slim
@@ -3,7 +3,8 @@
     a.list-group-item href=(monthly_report_path(report))
       = report.user.groups.map { |g| "【#{g.name}G】" }.join
       = "#{report.user.name} - #{report.target_month.strftime("%Y年%m月")}分"
-      small.text-muted = " 投稿日:#{report.shipped_at.strftime("%Y-%m-%d")}"
+      small#monthly-report-shipped-at.text-muted
+        = "投稿日:#{report.shipped_at.strftime("%Y-%m-%d")}"
       - tags = report.monthly_report_tags.order('monthly_report_tags.id')
       .pull-right
         - tags.first(3).each do |tag|

--- a/app/views/layouts/_report_index.html.slim
+++ b/app/views/layouts/_report_index.html.slim
@@ -3,6 +3,7 @@
     a.list-group-item href=(monthly_report_path(report))
       = report.user.groups.map { |g| "【#{g.name}G】" }.join
       = "#{report.user.name} - #{report.target_month.strftime("%Y年%m月")}分"
+      = " (投稿日:#{report.shipped_at.strftime("%Y-%m-%d")})"
       - tags = report.monthly_report_tags.order('monthly_report_tags.id')
       .pull-right
         - tags.first(3).each do |tag|

--- a/app/views/layouts/_report_index.html.slim
+++ b/app/views/layouts/_report_index.html.slim
@@ -3,7 +3,7 @@
     a.list-group-item href=(monthly_report_path(report))
       = report.user.groups.map { |g| "【#{g.name}G】" }.join
       = "#{report.user.name} - #{report.target_month.strftime("%Y年%m月")}分"
-      = " (投稿日:#{report.shipped_at.strftime("%Y-%m-%d")})"
+      small.text-muted = " 投稿日:#{report.shipped_at.strftime("%Y-%m-%d")}"
       - tags = report.monthly_report_tags.order('monthly_report_tags.id')
       .pull-right
         - tags.first(3).each do |tag|


### PR DESCRIPTION
# 概要
月報一覧で投稿日(公開日)を表示する

# 再現・確認手順
host:port/monthly_reportsにアクセスする

# 対応Issue（任意）
月報一覧で投稿日を表示する
https://github.com/hr-dash/hr-dash/issues/414

# ToDo

- [x] ラベル付け
- [x] Assigneesで自分を選択
