### PR TITLE
#406 対象月を検索項目に含める

### DIFF
--- a/app/controllers/monthly_reports_controller.rb
+++ b/app/controllers/monthly_reports_controller.rb
@@ -125,6 +125,7 @@ class MonthlyReportsController < ApplicationController
     search_conditions = [
       :user_groups_id_eq,
       :user_name_cont,
+      :target_month_eq,
       tags_name_in: [],
     ].concat(process_conditions)
 

--- a/app/models/monthly_report.rb
+++ b/app/models/monthly_report.rb
@@ -103,7 +103,7 @@ class MonthlyReport < ActiveRecord::Base
     return [] if MonthlyReport.released.blank?
     first_month = MonthlyReport.released.minimum(:target_month)
     last_month = MonthlyReport.released.maximum(:target_month)
-    all_months(first_month, last_month).map{ |month| [month.strftime('%Y年%m月'), month] }
+    all_months(first_month, last_month).map { |month| [month.strftime('%Y年%m月'), month] }
   end
 
   def self.all_months(first_month, last_month)

--- a/app/models/monthly_report.rb
+++ b/app/models/monthly_report.rb
@@ -100,9 +100,10 @@ class MonthlyReport < ActiveRecord::Base
   end
 
   def self.target_month_select_options
-    return [] if MonthlyReport.released.blank?
-    first_month = MonthlyReport.released.minimum(:target_month)
-    last_month = MonthlyReport.released.maximum(:target_month)
+    released_reports = MonthlyReport.released
+    return [] if released_reports.blank?
+    first_month = released_reports.minimum(:target_month)
+    last_month = released_reports.maximum(:target_month)
     all_months(first_month, last_month).map { |month| [month.strftime('%Y年%m月'), month] }
   end
 

--- a/app/models/monthly_report.rb
+++ b/app/models/monthly_report.rb
@@ -101,13 +101,16 @@ class MonthlyReport < ActiveRecord::Base
 
   def self.target_month_select_options
     return [] if MonthlyReport.released.blank?
-    options = []
-    month = MonthlyReport.released.minimum(:target_month)
-    while month <= MonthlyReport.released.maximum(:target_month)
-      options << [month.strftime('%Y年%m月'), month]
-      month = month.next_month
+    first_month = MonthlyReport.released.minimum(:target_month)
+    last_month = MonthlyReport.released.maximum(:target_month)
+    all_months(first_month, last_month).map{ |month| [month.strftime('%Y年%m月'), month] }
+  end
+
+  def self.all_months(first_month, last_month)
+    loop.each_with_object([first_month]) do |_, days|
+      nm = days.last.next_month
+      nm > last_month ? (break days) : days << nm
     end
-    options
   end
 
   private

--- a/app/models/monthly_report.rb
+++ b/app/models/monthly_report.rb
@@ -99,6 +99,17 @@ class MonthlyReport < ActiveRecord::Base
     shipped? || user == other_user
   end
 
+  def self.target_month_select_options
+    return [] if MonthlyReport.released.blank?
+    options = []
+    month = MonthlyReport.released.minimum(:target_month)
+    while month <= MonthlyReport.released.maximum(:target_month)
+      options << [month.strftime('%Y年%m月'), month]
+      month = month.next_month
+    end
+    options
+  end
+
   private
 
   def target_month_registrable_term

--- a/app/views/monthly_reports/index.html.slim
+++ b/app/views/monthly_reports/index.html.slim
@@ -27,6 +27,10 @@
                 = f.check_box column, { autocomplete: "off" }, true, nil
                 span = t "activerecord.attributes.monthly_working_process.#{process}"
         .form-group
+          = f.label :target_month_eq, '対象月', class: 'control-label col-xs-2'
+          .col-xs-10
+            = f.select :target_month_eq, options_for_select(MonthlyReport.target_month_select_options), { include_blank: true }, class: 'form-control'
+        .form-group
           .col-xs-10.col-xs-offset-2
             = f.button '検索', class: 'btn btn-default'
 .page-content

--- a/app/views/monthly_reports/index.html.slim
+++ b/app/views/monthly_reports/index.html.slim
@@ -14,6 +14,10 @@
           .col-xs-10
             = f.search_field :user_name_cont, class: 'form-control'
         .form-group
+          = f.label :target_month_eq, '対象月', class: 'control-label col-xs-2'
+          .col-xs-10
+            = f.select :target_month_eq, options_for_select(MonthlyReport.target_month_select_options, selected: @q.target_month_eq), { include_blank: true }, class: 'form-control'
+        .form-group
           = f.label :tags_name_in, '使用した技術', class: 'control-label col-xs-2'
           .col-xs-10
             = f.hidden_field :tags_name_in, id: :monthly_report_tags_input, class: 'form-control'
@@ -26,10 +30,6 @@
               label.btn.btn-default class=('active' if @q.send(column))
                 = f.check_box column, { autocomplete: "off" }, true, nil
                 span = t "activerecord.attributes.monthly_working_process.#{process}"
-        .form-group
-          = f.label :target_month_eq, '対象月', class: 'control-label col-xs-2'
-          .col-xs-10
-            = f.select :target_month_eq, options_for_select(MonthlyReport.target_month_select_options, selected: @q.target_month_eq), { include_blank: true }, class: 'form-control'
         .form-group
           .col-xs-10.col-xs-offset-2
             = f.button '検索', class: 'btn btn-default'

--- a/app/views/monthly_reports/index.html.slim
+++ b/app/views/monthly_reports/index.html.slim
@@ -29,7 +29,7 @@
         .form-group
           = f.label :target_month_eq, '対象月', class: 'control-label col-xs-2'
           .col-xs-10
-            = f.select :target_month_eq, options_for_select(MonthlyReport.target_month_select_options), { include_blank: true }, class: 'form-control'
+            = f.select :target_month_eq, options_for_select(MonthlyReport.target_month_select_options, selected: @q.target_month_eq), { include_blank: true }, class: 'form-control'
         .form-group
           .col-xs-10.col-xs-offset-2
             = f.button '検索', class: 'btn btn-default'

--- a/spec/features/monthly_report_spec.rb
+++ b/spec/features/monthly_report_spec.rb
@@ -30,6 +30,26 @@ describe MonthlyReportsController, type: :feature do
         it { expect(query).to include "q[tags_name_in][]=#{tag.name}" }
       end
     end
+
+    context 'by target_month' do
+      let(:url) { URI.parse(current_url) }
+      let(:query) { URI.decode(url.query) }
+      let!(:user1) { create(:user, entry_date: 6.months.ago) }
+      let(:month1) { 1.months.ago.beginning_of_month }
+      let(:month2) { 2.months.ago.beginning_of_month }
+      let!(:report1) { create(:monthly_report, :shipped, :with_tags, user: user1, target_month: month1) }
+      let!(:report2) { create(:monthly_report, :shipped, :with_tags, user: user1, target_month: month2) }
+
+      before do
+        visit monthly_reports_path
+        select report1.target_month.strftime('%Y年%m月'), from: 'q[target_month_eq]'
+        click_button '検索'
+      end
+
+      it { expect(current_path).to eq monthly_reports_path }
+      it { expect(query).to include "q[target_month_eq]=#{report1.target_month}" }
+      it { expect(query).not_to include "q[target_month_eq]=#{report2.target_month}" }
+    end
   end
 
   describe '#show GET /monthly_reports/:id' do

--- a/spec/models/monthly_report_spec.rb
+++ b/spec/models/monthly_report_spec.rb
@@ -235,7 +235,7 @@ RSpec.describe MonthlyReport, type: :model do
     end
   end
 
-  describe 'target_month_select_options' do
+  describe '.target_month_select_options' do
     let!(:user1) { create(:user, entry_date: 6.months.ago) }
     let(:month1) { 1.months.ago.beginning_of_month.to_date }
     let(:month2) { 2.months.ago.beginning_of_month.to_date }
@@ -246,7 +246,7 @@ RSpec.describe MonthlyReport, type: :model do
     it { is_expected.to eq [[month2.strftime('%Y年%m月'), month2], [month1.strftime('%Y年%m月'), month1]] }
   end
 
-  describe 'all_months' do
+  describe '.all_months' do
     let!(:user1) { create(:user, entry_date: 6.months.ago) }
     let(:month1) { 1.months.ago.beginning_of_month.to_date }
     let(:month2) { 2.months.ago.beginning_of_month.to_date }

--- a/spec/models/monthly_report_spec.rb
+++ b/spec/models/monthly_report_spec.rb
@@ -237,12 +237,25 @@ RSpec.describe MonthlyReport, type: :model do
 
   describe 'target_month_select_options' do
     let!(:user1) { create(:user, entry_date: 6.months.ago) }
-    let(:month1) { 1.months.ago.beginning_of_month }
-    let(:month2) { 2.months.ago.beginning_of_month }
+    let(:month1) { 1.months.ago.beginning_of_month.to_date }
+    let(:month2) { 2.months.ago.beginning_of_month.to_date }
     let!(:report1) { create(:monthly_report, :shipped, :with_tags, user: user1, target_month: month1) }
     let!(:report2) { create(:monthly_report, :shipped, :with_tags, user: user1, target_month: month2) }
 
     subject { MonthlyReport.target_month_select_options }
-    it { is_expected.to eq [[month2.strftime('%Y年%m月'), month2.to_date], [month1.strftime('%Y年%m月'), month1.to_date]] }
+    it { is_expected.to eq [[month2.strftime('%Y年%m月'), month2], [month1.strftime('%Y年%m月'), month1]] }
+  end
+
+  describe 'all_months' do
+    let!(:user1) { create(:user, entry_date: 6.months.ago) }
+    let(:month1) { 1.months.ago.beginning_of_month.to_date }
+    let(:month2) { 2.months.ago.beginning_of_month.to_date }
+    let(:month3) { 3.months.ago.beginning_of_month.to_date }
+    let(:month4) { 4.months.ago.beginning_of_month.to_date }
+    let!(:report1) { create(:monthly_report, :shipped, :with_tags, user: user1, target_month: month1) }
+    let!(:report2) { create(:monthly_report, :shipped, :with_tags, user: user1, target_month: month4) }
+
+    subject { MonthlyReport.all_months(month4, month1) }
+    it { is_expected.to eq [month4, month3, month2, month1] }
   end
 end

--- a/spec/models/monthly_report_spec.rb
+++ b/spec/models/monthly_report_spec.rb
@@ -234,4 +234,15 @@ RSpec.describe MonthlyReport, type: :model do
       it { is_expected.to eq false }
     end
   end
+
+  describe 'target_month_select_options' do
+    let!(:user1) { create(:user, entry_date: 6.months.ago) }
+    let(:month1) { 1.months.ago.beginning_of_month }
+    let(:month2) { 2.months.ago.beginning_of_month }
+    let!(:report1) { create(:monthly_report, :shipped, :with_tags, user: user1, target_month: month1) }
+    let!(:report2) { create(:monthly_report, :shipped, :with_tags, user: user1, target_month: month2) }
+
+    subject { MonthlyReport.target_month_select_options }
+    it { is_expected.to eq [[month2.strftime('%Y年%m月'), month2.to_date], [month1.strftime('%Y年%m月'), month1.to_date]] }
+  end
 end


### PR DESCRIPTION
# 概要
対象月を検索項目に含める

# 再現・確認手順
ログインする⇒画面左の「月報」をクリック⇒「トップ」をクリックして月報トップ画面に移動
「対象月」を指定するとその対象月の月報だけが表示される
「対象月」を指定しない場合はすべての対象月の月報が表示される
「対象月」での検索と他の検索項目による検索を同時に行うこともできる

# 対応Issue（任意）
対象月を検索項目に含める #406

# ToDo
- [x] ラベル付け
- [x] Assigneesで自分を選択
- [x] 動作確認
- [x] bundle exec rubocop
- [x] bundle exec rspec

# レビューにあたって
*selectフォームの検索対象を作成するために、
MonthlyReport.target_month_select_optionsというメソッドを作成しました。

この中では
(1)投稿されている全ての月報(MonthlyReport.released)の最小値と最大値を取得
(2)一番昔の対象月～一番最新の対象月の配列をselectとbeginning_of_monthで取得する
(3)<[X年Y月, target_month]という配列>の配列をmapで返す
という動きをしています。

months = (first_month..last_month).select { |day| day == day.beginning_of_month }
の部分は特に、「他にもっと簡潔な方法はないかな？」と考えています。

*「一番昔の対象月～一番最新の対象月の間の月をすべて表示する」という前提でOKでしょうか？
*伊豆田さん、田中さん、メソッドについてのコメントをありがとうございました。