### PR TITLE
他人の下書き中の月報が閲覧できてしまうのを修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+  class Forbidden < ActionController::ActionControllerError; end
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -3,6 +3,7 @@ class ErrorsController < ActionController::Base
 
   rescue_from StandardError, with: :render_internal_server_error
   rescue_from ActionController::NotImplemented, with: :render_not_implemented
+  rescue_from ApplicationController::Forbidden, with: :render_forbidden
   rescue_from ActionController::RoutingError, with: :render_not_found
   rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
   rescue_from ActionController::MethodNotAllowed, with: :render_method_not_allowed
@@ -10,6 +11,11 @@ class ErrorsController < ActionController::Base
   rescue_from ActiveRecord::RecordInvalid, with: :render_unprocessable_entity
   rescue_from ActiveRecord::RecordNotSaved, with: :render_unprocessable_entity
   rescue_from ActionController::InvalidAuthenticityToken, with: :render_unprocessable_entity
+
+  def render_forbidden(exception = nil)
+    log_error(exception)
+    render template: 'errors/403', status: 403
+  end
 
   def render_not_found(exception = nil)
     log_error(exception)

--- a/app/controllers/monthly_reports_controller.rb
+++ b/app/controllers/monthly_reports_controller.rb
@@ -13,6 +13,7 @@ class MonthlyReportsController < ApplicationController
 
   def show
     @monthly_report = MonthlyReport.includes(comments: { user: :user_profile }).find(params[:id])
+    fail(Forbidden, 'can not see wip reports of other users') unless browseable?(@monthly_report)
   end
 
   def new
@@ -60,6 +61,10 @@ class MonthlyReportsController < ApplicationController
   end
 
   private
+
+  def browseable?(monthly_report)
+    monthly_report.browseable?(current_user)
+  end
 
   def flash_errors(monthly_report)
     flash.now[:error] = monthly_report.errors.full_messages

--- a/app/models/monthly_report.rb
+++ b/app/models/monthly_report.rb
@@ -95,6 +95,10 @@ class MonthlyReport < ActiveRecord::Base
     users.uniq
   end
 
+  def browseable?(other_user)
+    shipped? || user == other_user
+  end
+
   private
 
   def target_month_registrable_term

--- a/app/views/errors/403.html.slim
+++ b/app/views/errors/403.html.slim
@@ -1,0 +1,2 @@
+- provide :error_status, '403'
+- provide :error_message, 'Forbidden'

--- a/app/views/monthly_reports/show.html.slim
+++ b/app/views/monthly_reports/show.html.slim
@@ -5,7 +5,7 @@
     .panel-heading.monthly-report-panel-header
       .panel-title.row
         .col-xs-2
-          - if @monthly_report.prev_month
+          - if @monthly_report.prev_month.try(:browseable?, current_user)
             a.btn.btn-default.btn-xs.monthly-report-panel-button href=(monthly_report_path(@monthly_report.prev_month)) role="button" 先月
         .col-xs-8.monthly-report-panel-date 
           - if @monthly_report.shipped?
@@ -14,7 +14,7 @@
             span.label.label-info.monthly-report-status 下書き
           = "#{@monthly_report.target_month.strftime("%Y年%m月")}の月報"
         .col-xs-2
-          - if @monthly_report.next_month
+          - if @monthly_report.next_month.try(:browseable?, current_user)
             a.btn.btn-default.btn-xs.monthly-report-panel-button.pull-right href=(monthly_report_path(@monthly_report.next_month)) role="button" 来月
     .panel-body
       form.form-horizontal

--- a/spec/factories/monthly_report.rb
+++ b/spec/factories/monthly_report.rb
@@ -43,6 +43,6 @@ FactoryGirl.define do
       end
     end
 
-    factory :shipped_montly_report, traits: [:shipped, :with_tags]
+    factory :shipped_monthly_report, traits: [:shipped, :with_tags]
   end
 end

--- a/spec/features/monthly_report_spec.rb
+++ b/spec/features/monthly_report_spec.rb
@@ -11,4 +11,15 @@ describe MonthlyReportsController, type: :feature do
       it { expect(first_report[:href]).to eq monthly_report_path(today) }
     end
   end
+
+  describe '#show GET /monthly_reports/:id' do
+    let(:user) { create(:user) }
+    let(:report) { create(:shipped_monthly_report, user: user) }
+    let!(:prev) { create(:shipped_monthly_report, user: user, target_month: report.target_month.prev_month) }
+    let!(:next) { create(:monthly_report, :wip, user: user, target_month: report.target_month.next_month) }
+    before { visit monthly_report_path(report) }
+
+    it { expect(page).to have_link('先月') }
+    it { expect(page).not_to have_link('来月') }
+  end
 end

--- a/spec/models/monthly_report_spec.rb
+++ b/spec/models/monthly_report_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe MonthlyReport, type: :model do
     end
 
     context 'when report is shipped' do
-      subject { build(:shipped_montly_report) }
+      subject { build(:shipped_monthly_report) }
       it { is_expected.to be_valid }
       it_behaves_like 'common validations'
 
@@ -147,7 +147,7 @@ RSpec.describe MonthlyReport, type: :model do
     end
 
     context 'exist last month report' do
-      before { create(:shipped_montly_report, target_month: report.target_month.last_month, user: user) }
+      before { create(:shipped_monthly_report, target_month: report.target_month.last_month, user: user) }
       it { expect { subject }.not_to raise_error }
     end
   end

--- a/spec/models/monthly_report_spec.rb
+++ b/spec/models/monthly_report_spec.rb
@@ -218,4 +218,20 @@ RSpec.describe MonthlyReport, type: :model do
       it { is_expected.to match_array([user, comment_user1, comment_user2]) }
     end
   end
+
+  describe '#browseable?' do
+    subject { report.browseable?(user) }
+    let(:user) { create(:user) }
+
+    context 'related user' do
+      let(:report) { create(:monthly_report, user: user) }
+      it { is_expected.to eq true }
+    end
+
+    context 'no related user' do
+      let(:report) { create(:monthly_report, user: other_user) }
+      let(:other_user) { create(:user) }
+      it { is_expected.to eq false }
+    end
+  end
 end

--- a/spec/requests/monthly_report_spec.rb
+++ b/spec/requests/monthly_report_spec.rb
@@ -28,10 +28,36 @@ describe MonthlyReportsController, type: :request do
   end
 
   describe '#show GET /monthly_reports/:id' do
-    before { get monthly_report_path(report) }
-    it { expect(response).to have_http_status :success }
-    it { expect(response).to render_template('monthly_reports/show') }
-    it { expect(response.body).to match report.user.name }
+    context 'my report registered as shipped' do
+      let(:report) { create(:shipped_monthly_report, user: user) }
+      before { get monthly_report_path(report) }
+      it { expect(response).to have_http_status :ok }
+      it { expect(response).to render_template('monthly_reports/show') }
+      it { expect(response.body).to match report.user.name }
+    end
+
+    context 'my report registered as wip' do
+      let(:report) { create(:monthly_report, :wip, user: user) }
+      before { get monthly_report_path(report) }
+      it { expect(response).to have_http_status :ok }
+      it { expect(response).to render_template('monthly_reports/show') }
+      it { expect(response.body).to match report.user.name }
+    end
+
+    context 'report registered as shipped by other user' do
+      let(:other_report) { create(:shipped_monthly_report) }
+      before { get monthly_report_path(other_report) }
+      it { expect(response).to have_http_status :ok }
+      it { expect(response).to render_template 'monthly_reports/show' }
+      it { expect(response.body).to match other_report.user.name }
+    end
+
+    context 'report registered as wip by other user' do
+      let(:other_report) { create(:monthly_report, :wip) }
+      before { get monthly_report_path(other_report) }
+      it { expect(response).to have_http_status :forbidden }
+      it { expect(response).to render_template 'errors/403' }
+    end
   end
 
   describe '#new GET /monthly_reports/new' do

--- a/spec/requests/monthly_report_spec.rb
+++ b/spec/requests/monthly_report_spec.rb
@@ -1,5 +1,5 @@
 describe MonthlyReportsController, type: :request do
-  let!(:report) { create(:shipped_montly_report, :with_comments) }
+  let!(:report) { create(:shipped_monthly_report, :with_comments) }
   let(:user) { create(:user) }
   before { login user }
 
@@ -192,7 +192,7 @@ describe MonthlyReportsController, type: :request do
 
     context 'valid' do
       context 'If monthly report on the last month has been registered' do
-        let!(:prev_monthly_report) { create(:shipped_montly_report) }
+        let!(:prev_monthly_report) { create(:shipped_monthly_report) }
         let(:params) { { target_month: prev_monthly_report.target_month.next_month.beginning_of_month } }
         before do
           login prev_monthly_report.user


### PR DESCRIPTION
# 概要
下書きである他人の月報を閲覧できてしまうので、それを修正

# 再現・確認手順

## 他人の下書きである月報は閲覧できない
1. 下書きの月報を作成
2. 別のユーザーでログイン
3. `/monthly_reports/:id` から `1` で作成した月報閲覧画面へ移動
4. エラーページが表示される

## 下書きの月報の場合、先月・来月のリンクが表示されなくなる
1. 下書きの月報を作成
2. `1` で作成した月報の先月または来月の月報を登録済みで作成する
3. 別のユーザーでログイン
4. `/monthly_reports/:id` から `2` で作成した月報閲覧画面へ移動
5. 先月または来月のリンクが表示されない

# 対応Issue（任意）
#407 

# ToDo

- [x] ラベル付け
- [x] Assigneesで自分を選択
