### PR TITLE
アクティブでないユーザーはグループのメンバー一覧に表示しない

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -58,6 +58,8 @@ class User < ActiveRecord::Base
   devise :database_authenticatable,
          :recoverable, :rememberable, :trackable, :validatable, :lockable
 
+  scope :active, -> { where('deleted_at IS NULL OR deleted_at > ?', Time.current) }
+
   class << self
     def find_for_database_authentication(warden_conditions)
       find_by(encrypted_email: encrypt(warden_conditions[:email]))

--- a/app/views/layouts/_group_tab.html.slim
+++ b/app/views/layouts/_group_tab.html.slim
@@ -12,6 +12,6 @@ div.row.group-tab
           = simple_format(h(group.description))
         .col-md-5
           h5 メンバー
-          - group.users.each do |user|
+          - group.users.active.each do |user|
             p = link_to user.name, user_profile_path(user.user_profile), class: 'text-info'
   

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -84,6 +84,26 @@ describe User, type: :model do
     it { expect(profile).to be_present }
   end
 
+  describe '.active' do
+    let!(:user) { create(:user, deleted_at: deleted_at) }
+    subject { described_class.active.present? }
+
+    context 'when deleted_at is nil' do
+      let(:deleted_at) { nil }
+      it { is_expected.to eq true }
+    end
+
+    context 'when deleted_at is future' do
+      let(:deleted_at) { Time.current.tomorrow }
+      it { is_expected.to eq true }
+    end
+
+    context 'when deleted_at is past' do
+      let(:deleted_at) { Time.current.yesterday }
+      it { is_expected.to eq false }
+    end
+  end
+
   describe '#report_registrable_months' do
     let(:entry_date) { Date.new(2016, 1, 1) }
     let(:user) { create(:user, entry_date: entry_date) }


### PR DESCRIPTION
# 概要
アクティブでないユーザーはグループのメンバー一覧に表示しない

グループ割当てから外せばOKだけど、 `User#deleted_at` を設定してるならそれも参照するようにする

# 再現・確認手順
`deleted_at` を本日より前に設定した場合、グループ一覧に表示されないこと

# 対応Issue（任意）
なし

# ToDo

- [x] ラベル付け
- [x] Assigneesで自分を選択
