### PR TITLE
月報登録通知メールの月報概要をtextのまま表示する

### DIFF
--- a/app/views/mailer/notify/monthly_report_registration.text.erb
+++ b/app/views/mailer/notify/monthly_report_registration.text.erb
@@ -7,6 +7,6 @@
 <%= @report.target_month.strftime('%Y年%m月') %>の業務報告
 -------------------------------------------------------------
 【プロジェクト概要】
-<%= simple_format(h(@report.project_summary)) %>
+<%= @report.project_summary %>
 <%= monthly_report_url(@report) %>
 -------------------------------------------------------------


### PR DESCRIPTION
# 概要
月報登録通知メールの月報概要をtextのまま表示する

# 再現・確認手順
月報登録して通知メールの内容を確認

# 対応Issue（任意）
https://github.com/hr-dash/hr-dash/issues/409

# ToDo

- [x] ラベル付け
- [x] Assigneesで自分を選択
