### PR TITLE
前月コピーボタンの見た目を修正

### DIFF
--- a/app/assets/stylesheets/main/monthly_reports.scss
+++ b/app/assets/stylesheets/main/monthly_reports.scss
@@ -23,3 +23,7 @@ a#edit-monthly-button {
 small.monthly-report-shipped-at {
   padding-left: 10px;
 }
+
+#prev_month_report_copy {
+  margin-bottom: 2rem;
+}

--- a/app/views/monthly_reports/_form.html.slim
+++ b/app/views/monthly_reports/_form.html.slim
@@ -1,6 +1,7 @@
 .page-content.well
   - if params[:action] == 'new' && monthly_report.prev_month
-    = button_to '先月の月報をコピー', { action: 'copy' }, params: { target_month: monthly_report.target_month }, method: 'get'
+    #prev_month_report_copy
+      = link_to '先月の月報をコピー', { action: 'copy', target_month: monthly_report.target_month }, class: 'btn btn-default'
 
   = form_for monthly_report, html: { class: 'form-horizontal' } do |f|
     - placeholders = HelpText.placeholders(:monthly_report)


### PR DESCRIPTION
# 概要
前月コピーボタンの見た目を修正
[Assets分割](https://github.com/hr-dash/hr-dash/pull/416) の影響でCSSが適用されなくなっていたので、修正した

# 再現・確認手順
前月が登録してある状態で月報新規作成画面へ飛ぶ

# 対応Issue（任意）
なし

# ToDo

- [x] ラベル付け
- [x] Assigneesで自分を選択
