### PR TITLE
#440 月報を検索した後のページングで500エラーが発生する

### DIFF
--- a/app/controllers/monthly_reports_controller.rb
+++ b/app/controllers/monthly_reports_controller.rb
@@ -120,7 +120,7 @@ class MonthlyReportsController < ApplicationController
 
   def search_params
     return unless params[:q]
-    params[:q][:tags_name_in] = params[:q][:tags_name_in].split(',')
+    params[:q][:tags_name_in] = params[:q][:tags_name_in]&.split(',')&.flatten
 
     search_conditions = [
       :user_groups_id_eq,

--- a/spec/features/monthly_report_spec.rb
+++ b/spec/features/monthly_report_spec.rb
@@ -10,6 +10,27 @@ describe MonthlyReportsController, type: :feature do
       before { visit monthly_reports_path }
       it { expect(first_report[:href]).to eq monthly_report_path(today) }
     end
+
+    describe 'search', js: true do
+      context 'by tag name' do
+        let!(:report) { create(:monthly_report, :shipped, :with_tags, tag_size: 1) }
+        let!(:tag) { report.tags.first }
+        let(:url) { URI.parse(current_url) }
+        let(:query) { URI.decode(url.query) }
+
+        before do
+          create_list(:monthly_report, 10, :shipped, tags: report.tags)
+          visit monthly_reports_path
+          find('#monthly_report_tags_input').set(tag.name)
+          click_button '検索'
+          click_link '>'
+        end
+
+        it { expect(current_path).to eq monthly_reports_path }
+        it { expect(find('div.tag > span').text).to eq tag.name }
+        it { expect(query).to include "q[tags_name_in][]=#{tag.name}" }
+      end
+    end
   end
 
   describe '#show GET /monthly_reports/:id' do

--- a/spec/features/monthly_report_spec.rb
+++ b/spec/features/monthly_report_spec.rb
@@ -13,13 +13,12 @@ describe MonthlyReportsController, type: :feature do
 
     describe 'search', js: true do
       context 'by tag name' do
-        let!(:report) { create(:monthly_report, :shipped, :with_tags, tag_size: 1) }
-        let!(:tag) { report.tags.first }
+        let!(:tag) { create(:tag) }
         let(:url) { URI.parse(current_url) }
         let(:query) { URI.decode(url.query) }
 
         before do
-          create_list(:monthly_report, 10, :shipped, tags: report.tags)
+          create_list(:monthly_report, 11, :shipped, tags: [tag])
           visit monthly_reports_path
           find('#monthly_report_tags_input').set(tag.name)
           click_button '検索'


### PR DESCRIPTION
# 概要
* 検索で絞った後にページングするとエラーが発生する。
* `params[:q][:tags_name_in].split(',')` で`nomethod_error` params[:q][:tags_name_in]がnilになっている模様
# 再現・確認手順
#440 を参照

# 対応Issue（任意）
#440 

# 原因
ransak用のパラメータtags_name_inの値がない場合に発生する。以下の２通りの場合にnilになる。

> 1) 検索時に最近使用した技術を指定していない場合。
> 2) 最近使用した技術を指定して、２回目のページを切り替えるなど、同じパラメータを使い回す場合

1の場合はそもそもがnilになるが、2の場合はsplit(',')で二次元配列になるため取得できていない
# ToDo

- [x] ラベル付け
- [x] Assigneesで自分を選択
