### PR TITLE
Tagに新たなstatusを追加する

### DIFF
--- a/app/admin/tag.rb
+++ b/app/admin/tag.rb
@@ -12,4 +12,14 @@ ActiveAdmin.register Tag do
     end
     f.actions
   end
+
+  batch_action 'fixedにする' do |ids|
+    Tag.where(id: ids).each(&:fixed!)
+    redirect_to collection_path, notice: "#{ids.size}個のタグをfixedにしました"
+  end
+
+  batch_action 'ignoredにする' do |ids|
+    Tag.where(id: ids).each(&:ignored!)
+    redirect_to collection_path, notice: "#{ids.size}個のタグをignoredにしました"
+  end
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -15,7 +15,7 @@ class Tag < ActiveRecord::Base
   validates :status, presence: true
   validates :name, length: { maximum: 32 }, presence: true, format: { with: VALID_NAME_REGEX }
 
-  enum status: { unfixed: 0, fixed: 1 }
+  enum status: { unfixed: 0, fixed: 1, ignored: 2 }
 
   def self.find_or_initialize_by_name_ignore_case(name)
     Tag.where('LOWER(name) = LOWER(?)', name).first || Tag.new(name: name)

--- a/spec/factories/tag.rb
+++ b/spec/factories/tag.rb
@@ -10,5 +10,9 @@ FactoryGirl.define do
     trait :fixed do
       status Tag.statuses[:fixed]
     end
+
+    trait :ignored do
+      status Tag.statuses[:ignored]
+    end
   end
 end

--- a/spec/features/admin/tag_spec.rb
+++ b/spec/features/admin/tag_spec.rb
@@ -43,4 +43,28 @@ describe 'Admin::Tag', type: :feature do
     it { expect(page).to have_content(new_name) }
     it { expect(tag.reload.name).to eq new_name }
   end
+
+  describe 'batch_action', js: true do
+    let!(:tag) { create(:tag, :unfixed) }
+
+    before do
+      visit admin_tags_path
+      check "batch_action_item_#{tag.id}"
+      click_on '一括操作'
+    end
+
+    context 'fixedにする' do
+      before { click_on '選択した行をfixedにする' }
+
+      it { expect(page).to have_content('1個のタグをfixedにしました') }
+      it { expect(tag.reload).to be_fixed }
+    end
+
+    context 'ignoredにする' do
+      before { click_on '選択した行をignoredにする' }
+
+      it { expect(page).to have_content('1個のタグをignoredにしました') }
+      it { expect(tag.reload).to be_ignored }
+    end
+  end
 end


### PR DESCRIPTION
# 概要
- Tagに新たなstatusを追加する
- 管理画面からタグのステータスを一括で変更できる機能をつける

2件に対応
一括変更時、 `unfixed` へ変えるユースケースは無いため追加していない

# 再現・確認手順
管理画面のタグ編集で `ignored` に変更できること
管理画面のタグ一覧から `fixed` `ignored` へ一括変更できること

# 対応Issue（任意）
https://github.com/hr-dash/hr-dash/issues/400
https://github.com/hr-dash/hr-dash/issues/408

# ToDo

- [x] ラベル付け
- [x] Assigneesで自分を選択
