### PR TITLE
bulletの指摘に対応する

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,7 +10,9 @@ Metrics/LineLength:
   Max: 128
 
 Metrics/BlockLength:
-  Enabled: false
+  Exclude:
+    - spec/**/*
+    - app/admin/**/*
 
 TrailingCommaInArguments:
   EnforcedStyleForMultiline: comma

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,10 +18,6 @@ TrailingCommaInArguments:
 TrailingCommaInLiteral:
   EnforcedStyleForMultiline: comma
 
-# frozen string literal を付けていなくても警告しない
-Style/FrozenStringLiteralComment:
-  Enabled: false
-
 AllCops:
   Exclude:
     - db/schema.rb

--- a/Capfile
+++ b/Capfile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Load DSL and set up stages
 require 'capistrano/setup'
 

--- a/app/admin/active_admin_action_log.rb
+++ b/app/admin/active_admin_action_log.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ActiveAdmin.register ActiveAdminActionLog do
   menu label: 'ログ'
   actions :index, :show

--- a/app/admin/announcement.rb
+++ b/app/admin/announcement.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ActiveAdmin.register Announcement do
   active_admin_action_log
   permit_params { Announcement.column_names }

--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ActiveAdmin.register_page 'Dashboard' do
   DISPLAY_MONTHLY_REPORT_LIMIT = 10
   DISPLAY_UNFIXED_TAG_LIMIT = 10

--- a/app/admin/group.rb
+++ b/app/admin/group.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ActiveAdmin.register Group do
   menu parent: 'グループ'
   csv_importable

--- a/app/admin/group_assignment.rb
+++ b/app/admin/group_assignment.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ActiveAdmin.register GroupAssignment do
   menu parent: 'グループ'
   active_admin_action_log

--- a/app/admin/help_text.rb
+++ b/app/admin/help_text.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ActiveAdmin.register HelpText do
   active_admin_action_log
   permit_params { HelpText.column_names }

--- a/app/admin/inquiry.rb
+++ b/app/admin/inquiry.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ActiveAdmin.register Inquiry do
   active_admin_action_log
   permit_params { Inquiry.column_names }

--- a/app/admin/monthly_report.rb
+++ b/app/admin/monthly_report.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ActiveAdmin.register MonthlyReport do
   menu parent: '月報'
   active_admin_action_log

--- a/app/admin/monthly_report_comment.rb
+++ b/app/admin/monthly_report_comment.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ActiveAdmin.register MonthlyReportComment do
   menu parent: '月報'
   active_admin_action_log

--- a/app/admin/monthly_report_tag.rb
+++ b/app/admin/monthly_report_tag.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ActiveAdmin.register MonthlyReportTag do
   menu parent: '月報'
   active_admin_action_log

--- a/app/admin/monthly_working_process.rb
+++ b/app/admin/monthly_working_process.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ActiveAdmin.register MonthlyWorkingProcess do
   menu parent: '月報'
   active_admin_action_log

--- a/app/admin/tag.rb
+++ b/app/admin/tag.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ActiveAdmin.register Tag do
   csv_importable validate: false
   active_admin_action_log

--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ActiveAdmin.register User do
   menu parent: 'ユーザー'
   active_admin_action_log

--- a/app/admin/user_profile.rb
+++ b/app/admin/user_profile.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ActiveAdmin.register UserProfile do
   menu parent: 'ユーザー'
   active_admin_action_log

--- a/app/admin/user_role.rb
+++ b/app/admin/user_role.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ActiveAdmin.register UserRole do
   menu parent: 'ユーザー'
   active_admin_action_log

--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class AnnouncementsController < ApplicationController
   def index
     @announcements = Announcement.published.page params[:page]

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class ApplicationController < ActionController::Base
   class Forbidden < ActionController::ActionControllerError; end
   # Prevent CSRF attacks by raising an exception.

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class ErrorsController < ActionController::Base
   layout 'error'
 

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class GroupsController < ApplicationController
   def index
     @groups = Group.includes(users: :user_profile).active.order(:id)

--- a/app/controllers/inquiries_controller.rb
+++ b/app/controllers/inquiries_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class InquiriesController < ApplicationController
   def create
     @inquiry = Inquiry.new(permitted_params) { |i| i.user = current_user }

--- a/app/controllers/monthly_report_comments_controller.rb
+++ b/app/controllers/monthly_report_comments_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class MonthlyReportCommentsController < ApplicationController
   def create
     comment = MonthlyReportComment.new(permitted_params)

--- a/app/controllers/monthly_reports_controller.rb
+++ b/app/controllers/monthly_reports_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class MonthlyReportsController < ApplicationController
   def index
     references = [{ user: :groups }, :monthly_working_process, { monthly_report_tags: :tag }]

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class PasswordResetsController < Devise::PasswordsController
   layout false
 

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class RootController < ApplicationController
   def index
     references = [{ user: :groups }, :monthly_working_process, { monthly_report_tags: :tag }]

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class SessionsController < Devise::SessionsController
   layout false
 

--- a/app/controllers/user_profiles_controller.rb
+++ b/app/controllers/user_profiles_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class UserProfilesController < ApplicationController
   def show
     @profile = UserProfile.find(params[:id])

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ApplicationHelper
   def alert_class_for(flash_type)
     types = {

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class ApplicationMailer < ActionMailer::Base
   layout 'mailer'
 

--- a/app/mailers/devise_mailer.rb
+++ b/app/mailers/devise_mailer.rb
@@ -1,2 +1,3 @@
+# frozen_string_literal: true
 class DeviseMailer < Devise::Mailer
 end

--- a/app/mailers/mailer/error.rb
+++ b/app/mailers/mailer/error.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Mailer
   class Error < ApplicationMailer
     def create(exception, user, request)

--- a/app/mailers/mailer/inquiry.rb
+++ b/app/mailers/mailer/inquiry.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Mailer
   class Inquiry < ApplicationMailer
     def create(inquiry)

--- a/app/mailers/mailer/notify.rb
+++ b/app/mailers/mailer/notify.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Mailer
   class Notify < ApplicationMailer
     def monthly_report_registration(user_id, monthly_report_id)

--- a/app/models/active_admin_action_log.rb
+++ b/app/models/active_admin_action_log.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # == Schema Information
 #
 # Table name: active_admin_action_logs

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # == Schema Information
 #
 # Table name: announcements

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 end

--- a/app/models/concerns/encryptor.rb
+++ b/app/models/concerns/encryptor.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Encryptor
   extend ActiveSupport::Concern
 

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # == Schema Information
 #
 # Table name: groups

--- a/app/models/group_assignment.rb
+++ b/app/models/group_assignment.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # == Schema Information
 #
 # Table name: group_assignments

--- a/app/models/help_text.rb
+++ b/app/models/help_text.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # == Schema Information
 #
 # Table name: help_texts

--- a/app/models/inquiry.rb
+++ b/app/models/inquiry.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # == Schema Information
 #
 # Table name: inquiries

--- a/app/models/monthly_report.rb
+++ b/app/models/monthly_report.rb
@@ -18,7 +18,7 @@
 
 class MonthlyReport < ActiveRecord::Base
   belongs_to :user
-  has_many :comments, class_name: 'MonthlyReportComment', dependent: :destroy
+  has_many :comments, class_name: 'MonthlyReportComment', dependent: :delete_all
   has_many :monthly_report_tags, dependent: :destroy
   has_many :tags, through: :monthly_report_tags
   has_one :monthly_working_process, dependent: :destroy

--- a/app/models/monthly_report.rb
+++ b/app/models/monthly_report.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # == Schema Information
 #
 # Table name: monthly_reports

--- a/app/models/monthly_report_comment.rb
+++ b/app/models/monthly_report_comment.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # == Schema Information
 #
 # Table name: monthly_report_comments

--- a/app/models/monthly_report_tag.rb
+++ b/app/models/monthly_report_tag.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # == Schema Information
 #
 # Table name: monthly_report_tags

--- a/app/models/monthly_working_process.rb
+++ b/app/models/monthly_working_process.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # == Schema Information
 #
 # Table name: monthly_working_processes

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # == Schema Information
 #
 # Table name: tags

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # == Schema Information
 #
 # Table name: users

--- a/app/models/user_profile.rb
+++ b/app/models/user_profile.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # == Schema Information
 #
 # Table name: user_profiles

--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # == Schema Information
 #
 # Table name: user_roles

--- a/app/views/monthly_reports/_comment.html.slim
+++ b/app/views/monthly_reports/_comment.html.slim
@@ -2,7 +2,7 @@
   .panel-heading.monthly-report-panel-header
     = link_to comment.user.name, user_profile_path(comment.user.user_profile), class: 'text-info' 
     = ' さんが '
-    = link_to comment.updated_at, monthly_report_path(comment.monthly_report, anchor: "comment-#{comment.id}"), class: 'text-info'
+    = link_to comment.updated_at, monthly_report_path(comment.monthly_report.id, anchor: "comment-#{comment.id}"), class: 'text-info'
     = ' にコメント '
     - if comment.user == current_user
       .pull-right

--- a/bin/bundle
+++ b/bin/bundle
@@ -1,3 +1,4 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 load Gem.bin_path('bundler', 'bundle')

--- a/bin/rails
+++ b/bin/rails
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 begin
   load File.expand_path('../spring', __FILE__)
 rescue LoadError

--- a/bin/rake
+++ b/bin/rake
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 begin
   load File.expand_path('../spring', __FILE__)
 rescue LoadError

--- a/bin/rspec
+++ b/bin/rspec
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 begin
   load File.expand_path('../spring', __FILE__)
 rescue LoadError

--- a/bin/setup
+++ b/bin/setup
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 require 'pathname'
 require 'fileutils'
 include FileUtils

--- a/bin/spring
+++ b/bin/spring
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 # This file loads spring without using Bundler, in order to be fast.
 # It gets overwritten when you run the `spring binstub` command.

--- a/bin/update
+++ b/bin/update
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 require 'pathname'
 require 'fileutils'
 include FileUtils

--- a/config.ru
+++ b/config.ru
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # This file is used by Rack-based servers to start the application.
 
 require ::File.expand_path('../config/environment', __FILE__)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 [
   ActiveAdminActionLog,
   User,

--- a/lib/capistrano/tasks/db.rake
+++ b/lib/capistrano/tasks/db.rake
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 namespace :db do
   desc 'db:create'
   task :create do

--- a/lib/tasks/comments_counter.rake
+++ b/lib/tasks/comments_counter.rake
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 namespace :comments_counter do
   desc 'Calculate monthly_report_comments count'
   task calculate: :environment do

--- a/lib/tasks/notifer.rake
+++ b/lib/tasks/notifer.rake
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 namespace :notifer do
   desc 'Send email notification if user can register monthly report.'
   task report_registrable: :environment do

--- a/lib/tasks/tag_cleaner.rake
+++ b/lib/tasks/tag_cleaner.rake
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 namespace :tag_cleaner do
   desc 'Delete unfixed, unused tags. if no args, dry_run.'
   task :delete_unused_tags, ['exec_flag'] => :environment do |_, args|

--- a/spec/factories/announcements.rb
+++ b/spec/factories/announcements.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # == Schema Information
 #
 # Table name: announcements

--- a/spec/factories/group.rb
+++ b/spec/factories/group.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 FactoryGirl.define do
   factory :group do
     name { Faker::Name.name }

--- a/spec/factories/group_assignments.rb
+++ b/spec/factories/group_assignments.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # == Schema Information
 #
 # Table name: group_assignments

--- a/spec/factories/help_texts.rb
+++ b/spec/factories/help_texts.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # == Schema Information
 #
 # Table name: help_texts

--- a/spec/factories/inquiries.rb
+++ b/spec/factories/inquiries.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # == Schema Information
 #
 # Table name: inquiries

--- a/spec/factories/monthly_report.rb
+++ b/spec/factories/monthly_report.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 FactoryGirl.define do
   factory :monthly_report do
     association :user

--- a/spec/factories/monthly_report_comment.rb
+++ b/spec/factories/monthly_report_comment.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 FactoryGirl.define do
   factory :monthly_report_comment do
     association :user

--- a/spec/factories/monthly_report_tag.rb
+++ b/spec/factories/monthly_report_tag.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 FactoryGirl.define do
   factory :monthly_report_tag do
     association :monthly_report

--- a/spec/factories/monthly_working_processes.rb
+++ b/spec/factories/monthly_working_processes.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # == Schema Information
 #
 # Table name: monthly_working_processes

--- a/spec/factories/tag.rb
+++ b/spec/factories/tag.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 FactoryGirl.define do
   factory :tag do
     status Tag.statuses[:fixed]

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 FactoryGirl.define do
   factory :user do
     name { Faker::Name.name }

--- a/spec/factories/user_profiles.rb
+++ b/spec/factories/user_profiles.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # == Schema Information
 #
 # Table name: user_profiles

--- a/spec/factories/user_role.rb
+++ b/spec/factories/user_role.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 FactoryGirl.define do
   factory :user_role do
     association :user

--- a/spec/features/admin/action_log_spec.rb
+++ b/spec/features/admin/action_log_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 describe 'Admin::HelpText', type: :feature do
   let(:page_title) { find('#page_title') }
   let(:new_group) { build(:group) }

--- a/spec/features/admin/dashboard_spec.rb
+++ b/spec/features/admin/dashboard_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 describe 'Admin::Dashboard', type: :feature do
   before do
     login(admin: true)

--- a/spec/features/admin/group_spec.rb
+++ b/spec/features/admin/group_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 describe 'Admin::Group', type: :feature do
   before { login(admin: true) }
   let(:group) { create(:group) }

--- a/spec/features/admin/help_text_spec.rb
+++ b/spec/features/admin/help_text_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 describe 'Admin::HelpText', type: :feature do
   before { login(admin: true) }
   let!(:help_text) { create(:help_text) }

--- a/spec/features/admin/inquiry_spec.rb
+++ b/spec/features/admin/inquiry_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 describe 'Admin::Inquiry', type: :feature do
   before { login(admin: true) }
   let!(:inquiry) { create(:inquiry) }

--- a/spec/features/admin/monthly_report_comment_spec.rb
+++ b/spec/features/admin/monthly_report_comment_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 describe 'Admin::MonthlyReportComment', type: :feature do
   before { login(user, admin: true) }
   let(:user) { create(:user) }

--- a/spec/features/admin/monthly_report_spec.rb
+++ b/spec/features/admin/monthly_report_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 describe 'Admin::MonthlyReport', type: :feature do
   before { login(user, admin: true) }
   let(:user) { create(:user) }

--- a/spec/features/admin/monthly_report_tag_spec.rb
+++ b/spec/features/admin/monthly_report_tag_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 describe 'Admin::MonthlyReportTag', type: :feature do
   before { login(user, admin: true) }
   let(:user) { create(:user) }

--- a/spec/features/admin/monthly_working_process_spec.rb
+++ b/spec/features/admin/monthly_working_process_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 describe 'Admin::MonthlyWorkingProcess', type: :feature do
   let(:page_title) { find('#page_title') }
   let!(:working_process) { create(:monthly_working_process) }

--- a/spec/features/admin/tag_spec.rb
+++ b/spec/features/admin/tag_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 describe 'Admin::Tag', type: :feature do
   before { login(admin: true) }
   let!(:tag) { create(:tag) }

--- a/spec/features/admin/user_profile_spec.rb
+++ b/spec/features/admin/user_profile_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 describe 'Admin::UserProfile', type: :feature do
   before { login(user, admin: true) }
   let(:user) { create(:user) }

--- a/spec/features/admin/user_role_spec.rb
+++ b/spec/features/admin/user_role_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 describe 'Admin::UserRole', type: :feature do
   before { login(admin: true) }
   let(:user) { create(:user) }

--- a/spec/features/admin/user_spec.rb
+++ b/spec/features/admin/user_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 describe 'Admin::User', type: :feature do
   before { login(user, admin: true) }
   let(:user) { create(:user) }

--- a/spec/features/admin/user_spec.rb
+++ b/spec/features/admin/user_spec.rb
@@ -116,7 +116,7 @@ describe 'Admin::User', type: :feature do
         accept_confirm { click_link('月報を削除する') }
       end
 
-      xit { expect(page).to have_content('月報を削除する') }
+      it { expect(page).to have_content('月報を削除する') }
       it { expect(target_user.monthly_reports).to be_blank }
       it { expect(tags).to be_blank }
       it { expect(comments).to be_blank }

--- a/spec/features/announcement_spec.rb
+++ b/spec/features/announcement_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 describe AnnouncementsController, type: :feature do
   before { login }
 

--- a/spec/features/inquiry_spec.rb
+++ b/spec/features/inquiry_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 describe InquiriesController, type: :feature do
   let(:user) { create(:user) }
   before { login user }

--- a/spec/features/monthly_report_comment_spec.rb
+++ b/spec/features/monthly_report_comment_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 describe MonthlyReportCommentsController, type: :feature do
   let(:user) { create(:user) }
   let(:report) { create(:monthly_report, :shipped, :with_tags) }

--- a/spec/features/monthly_report_spec.rb
+++ b/spec/features/monthly_report_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 describe MonthlyReportsController, type: :feature do
   before { login }
 

--- a/spec/features/password_reset_spec.rb
+++ b/spec/features/password_reset_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 describe PasswordResetsController, type: :feature do
   describe '#create' do
     let(:email) { user.email }

--- a/spec/features/root_spec.rb
+++ b/spec/features/root_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 describe RootController, type: :feature do
   before { login }
 

--- a/spec/features/session_spec.rb
+++ b/spec/features/session_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 describe SessionsController, type: :feature do
   describe '#new GET /sessions/new' do
     describe 'success' do

--- a/spec/mailers/notify_spec.rb
+++ b/spec/mailers/notify_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rails_helper'
 RSpec.describe Mailer::Notify, type: :mailer do
   let!(:report) { create(:monthly_report, :with_comments, :with_tags) }

--- a/spec/models/active_admin_action_log_spec.rb
+++ b/spec/models/active_admin_action_log_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # == Schema Information
 #
 # Table name: active_admin_action_logs

--- a/spec/models/announcement_spec.rb
+++ b/spec/models/announcement_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # == Schema Information
 #
 # Table name: announcements

--- a/spec/models/concerns/encryptor_spec.rb
+++ b/spec/models/concerns/encryptor_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 describe Encryptor, type: :model do
   class Sample
     include Encryptor

--- a/spec/models/group_assignment_spec.rb
+++ b/spec/models/group_assignment_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # == Schema Information
 #
 # Table name: group_assignments

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # == Schema Information
 #
 # Table name: groups

--- a/spec/models/help_text_spec.rb
+++ b/spec/models/help_text_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # == Schema Information
 #
 # Table name: help_texts

--- a/spec/models/inquiry_spec.rb
+++ b/spec/models/inquiry_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # == Schema Information
 #
 # Table name: inquiries

--- a/spec/models/monthly_report_comment_spec.rb
+++ b/spec/models/monthly_report_comment_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # == Schema Information
 #
 # Table name: monthly_report_comments

--- a/spec/models/monthly_report_spec.rb
+++ b/spec/models/monthly_report_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # == Schema Information
 #
 # Table name: monthly_reports

--- a/spec/models/monthly_report_tag_spec.rb
+++ b/spec/models/monthly_report_tag_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # == Schema Information
 #
 # Table name: monthly_report_tags

--- a/spec/models/monthly_working_process_spec.rb
+++ b/spec/models/monthly_working_process_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # == Schema Information
 #
 # Table name: monthly_working_processes

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # == Schema Information
 #
 # Table name: tags

--- a/spec/models/user_profile_spec.rb
+++ b/spec/models/user_profile_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # == Schema Information
 #
 # Table name: user_profiles

--- a/spec/models/user_role_spec.rb
+++ b/spec/models/user_role_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # == Schema Information
 #
 # Table name: user_roles

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # == Schema Information
 #
 # Table name: users

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV['RAILS_ENV'] = 'test'
 require File.expand_path('../../config/environment', __FILE__)

--- a/spec/requests/admin/dashboard_spec.rb
+++ b/spec/requests/admin/dashboard_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 describe Admin::DashboardController, type: :request do
   let(:user) { create :user }
   let!(:user_role) { create :user_role, role, user: user }

--- a/spec/requests/errors_spec.rb
+++ b/spec/requests/errors_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 describe ErrorsController, type: :request do
   after { ActionMailer::Base.deliveries.clear }
 

--- a/spec/requests/group_spec.rb
+++ b/spec/requests/group_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 describe GroupsController, type: :request do
   before { login }
 

--- a/spec/requests/monthly_report_spec.rb
+++ b/spec/requests/monthly_report_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 describe MonthlyReportsController, type: :request do
   let!(:report) { create(:shipped_monthly_report, :with_comments) }
   let(:user) { create(:user) }

--- a/spec/requests/user_profile_spec.rb
+++ b/spec/requests/user_profile_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 describe UserProfilesController, type: :request do
   let(:user) { create :user }
   let(:profile) { user.user_profile }

--- a/spec/routing/routes_spec.rb
+++ b/spec/routing/routes_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 describe 'Routing', type: :routing do
   describe '/monthly_reports/?page=:page' do
     let(:page_count_limit) { Constraints::PageCount::PAGE_COUNT_LIMIT }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Helpers
   def generate_random_password
     required_chars = ['A'..'Z', 'a'..'z', '0'..'9'].map do |range|

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 include Warden::Test::Helpers
 
 module RequestHelpers

--- a/spec/tasks/comments_counter_spec.rb
+++ b/spec/tasks/comments_counter_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 describe 'comments_counter' do
   let(:report) { create(:monthly_report, :with_comments, comment_size: comment_size) }
   let(:comment_size) { Faker::Number.between(1, 10) }

--- a/spec/tasks/notifer_spec.rb
+++ b/spec/tasks/notifer_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 describe 'notifer' do
   describe 'report_registrable' do
     let(:task) { Rake::Task['notifer:report_registrable'] }

--- a/spec/tasks/tag_cleaner_spec.rb
+++ b/spec/tasks/tag_cleaner_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 describe 'tag_cleaner' do
   describe 'delete_unused_tags' do
     let(:used_tag) { create(:tag, status: :unfixed) }

--- a/spec/whenever/schedule_spec.rb
+++ b/spec/whenever/schedule_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 describe Whenever do
   include Shoulda::Whenever
 


### PR DESCRIPTION
# 概要
#455 を参照。

# 再現・確認手順
なし

# 対応Issue（任意）
#455 
# ToDo

- [x] ラベル付け
- [x] Assigneesで自分を選択
- [x] レビュアーを2人指定する

# レビューにあたって
修正した理由はいずれもbullet（N+1問題を検出するgem）の警告で eager_load（関連オブジェクトをまとめて読み込み）しなさいというものでした。
* destroyからdelete_allにした理由は[これ](http://blog.aqutras.com/entry/2016/04/20/210000)をみていただければと思います。
* `commetn.monthly_report` を変更したのはこのパーシャルの呼び出し元で@monthly_reportを持っているのでそれを使えば無駄にクエリ発行しないためです。