### PR TITLE
月報登録失敗後に登録画面で【Update(月報を更新)】ボタンが表示されてしまう

### DIFF
--- a/app/controllers/monthly_reports_controller.rb
+++ b/app/controllers/monthly_reports_controller.rb
@@ -1,4 +1,6 @@
 class MonthlyReportsController < ApplicationController
+  before_action :assign_saved_report, only: [:edit, :update]
+
   def index
     references = [{ user: :groups }, :monthly_working_process, { monthly_report_tags: :tag }]
     @q = MonthlyReport.includes(references).ransack(search_params)
@@ -37,13 +39,9 @@ class MonthlyReportsController < ApplicationController
   end
 
   def edit
-    @monthly_report = current_user.monthly_reports.includes(monthly_report_tags: :tag).find params[:id]
-    @saved_shipped_at = @monthly_report.shipped_at
   end
 
   def update
-    @monthly_report = current_user.monthly_reports.find(params[:id])
-    @saved_shipped_at = @monthly_report.shipped_at
     @monthly_report.assign_attributes(permitted_params)
     assign_relational_params(@monthly_report)
     shipped_at_was = @monthly_report.shipped_at_was
@@ -63,6 +61,11 @@ class MonthlyReportsController < ApplicationController
   end
 
   private
+
+  def assign_saved_report
+    @monthly_report = current_user.monthly_reports.includes(monthly_report_tags: :tag).find params[:id]
+    @saved_shipped_at = @monthly_report.shipped_at
+  end
 
   def browseable?(monthly_report)
     monthly_report.browseable?(current_user)

--- a/app/controllers/monthly_reports_controller.rb
+++ b/app/controllers/monthly_reports_controller.rb
@@ -38,10 +38,12 @@ class MonthlyReportsController < ApplicationController
 
   def edit
     @monthly_report = current_user.monthly_reports.includes(monthly_report_tags: :tag).find params[:id]
+    @saved_shipped_at = @monthly_report.shipped_at
   end
 
   def update
     @monthly_report = current_user.monthly_reports.find(params[:id])
+    @saved_shipped_at = @monthly_report.shipped_at
     @monthly_report.assign_attributes(permitted_params)
     assign_relational_params(@monthly_report)
     shipped_at_was = @monthly_report.shipped_at_was

--- a/app/views/monthly_reports/_form.html.slim
+++ b/app/views/monthly_reports/_form.html.slim
@@ -50,7 +50,7 @@
       .col-xs-9
         == render 'layouts/markdown_editor', attr: :next_month_goals, form: f, placeholder: placeholders[:next_month_goals]
     = f.hidden_field :target_month
-    - if monthly_report.shipped?
+    - if @saved_shipped_at
       = f.button 'Update（月報を更新）', class: 'btn btn-lg btn-success btn-block'
     - else
       = f.button 'Save as WIP（下書き保存）', name: :wip, class: 'btn btn-lg btn-info btn-block'


### PR DESCRIPTION
# 概要
月報登録失敗後に登録画面で【Update(月報を更新)】ボタンが表示されてしまう

ボタンの制御は `monthly_report.shipped?` で行っていたが、登録時・更新直前に `shipped_at` に値を代入していたため、公開済みと判定されていた。
代入前の値を使ってボタンの制御を行なうよう変更

# 再現・確認手順
月報登録（create）でValidation Errorを起こすと、更新ボタンしか残らなくなる

# 対応Issue（任意）
https://github.com/hr-dash/hr-dash/issues/459

# ToDo

- [x] ラベル付け
- [x] Assigneesで自分を選択
- [x] レビュアーを2人指定する
