### PR TITLE
URLのprotocolをhttpsに変更

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -80,6 +80,6 @@ Rails.application.configure do
 
   # ActionMailerの設定
   config.action_mailer.delivery_method = :aws_sdk
-  config.action_mailer.default_url_options = { :host => ENV['MAILER_DEFAULT_HOST'] }
+  config.action_mailer.default_url_options = { protocol: :https, host: ENV['MAILER_DEFAULT_HOST'] }
   config.action_mailer.default_options = { from: "システム管理者 <#{ENV['MAILER_FROM']}>" }
 end


### PR DESCRIPTION
# 概要
URLのprotocolをhttpsに変更
既にhttpsでアクセスできるようになっているので、メール内に記載されるURLのプロトコルを `https` に変更する

# 再現・確認手順
`RAILS_ENV=production` もしくは同じ記述を `development` にしてみて月報登録等してみる

# 対応Issue（任意）

# ToDo

- [x] ラベル付け
- [x] Assigneesで自分を選択
- [x] レビュアーを2人指定する
