### PR TITLE
担当工程を増やす

### DIFF
--- a/app/controllers/monthly_reports_controller.rb
+++ b/app/controllers/monthly_reports_controller.rb
@@ -39,8 +39,7 @@ class MonthlyReportsController < ApplicationController
     end
   end
 
-  def edit
-  end
+  def edit; end
 
   def update
     @monthly_report.assign_attributes(permitted_params)

--- a/app/models/monthly_working_process.rb
+++ b/app/models/monthly_working_process.rb
@@ -12,6 +12,8 @@
 #  process_operation      :boolean          default(FALSE), not null
 #  process_analysis       :boolean          default(FALSE), not null
 #  process_training       :boolean          default(FALSE), not null
+#  process_structure      :boolean          default(FALSE), not null
+#  process_trouble        :boolean          default(FALSE), not null
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
 #

--- a/app/views/monthly_reports/index.html.slim
+++ b/app/views/monthly_reports/index.html.slim
@@ -24,7 +24,7 @@
             == render 'layouts/monthly_report_tags', tags: @q.tags_name_in, placeholder: placeholders[:tags]
         .form-group
           = f.label :monthly_working_process, '担当した工程', class: 'control-label col-xs-2'
-          .col-xs-10.btn-group data-toggle="buttons"
+          .col-xs-10.btn-group.btn-group-sm data-toggle="buttons"
             - MonthlyWorkingProcess::PROCESSES.each do |process|
               - column = "monthly_working_process_#{process}_eq"
               label.btn.btn-default class=('active' if @q.send(column))

--- a/config/locales/activerecord.ja.yml
+++ b/config/locales/activerecord.ja.yml
@@ -50,6 +50,8 @@ ja:
         process_operation: 運用保守
         process_analysis: 分析
         process_training: 研修
+        process_structure: 構築
+        process_trouble: 障害対応
       user_role:
         user: ユーザー
         role: ロール

--- a/db/migrate/20170303143632_add_infra_process_to_monthly_working_process.rb
+++ b/db/migrate/20170303143632_add_infra_process_to_monthly_working_process.rb
@@ -1,0 +1,6 @@
+class AddInfraProcessToMonthlyWorkingProcess < ActiveRecord::Migration
+  def change
+    add_column :monthly_working_processes, :process_structure, :boolean, null: false, default: false
+    add_column :monthly_working_processes, :process_trouble, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170107145744) do
+ActiveRecord::Schema.define(version: 20170303143632) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -128,6 +128,8 @@ ActiveRecord::Schema.define(version: 20170107145744) do
     t.boolean  "process_operation",      default: false, null: false
     t.boolean  "process_analysis",       default: false, null: false
     t.boolean  "process_training",       default: false, null: false
+    t.boolean  "process_structure",      default: false, null: false
+    t.boolean  "process_trouble",        default: false, null: false
     t.datetime "created_at",                             null: false
     t.datetime "updated_at",                             null: false
     t.index ["monthly_report_id"], name: "index_monthly_working_processes_on_monthly_report_id", using: :btree

--- a/spec/factories/monthly_report.rb
+++ b/spec/factories/monthly_report.rb
@@ -2,7 +2,7 @@
 FactoryGirl.define do
   factory :monthly_report do
     association :user
-    target_month { Faker::Date.between(6.months.ago, 1.months.ago).beginning_of_month }
+    target_month { Faker::Date.between(6.months.ago, 2.months.ago).beginning_of_month }
     project_summary { Faker::Lorem.paragraph }
     business_content { Faker::Lorem.paragraph }
     looking_back { Faker::Lorem.paragraph }

--- a/spec/factories/monthly_working_processes.rb
+++ b/spec/factories/monthly_working_processes.rb
@@ -12,6 +12,8 @@
 #  process_operation      :boolean          default(FALSE), not null
 #  process_analysis       :boolean          default(FALSE), not null
 #  process_training       :boolean          default(FALSE), not null
+#  process_structure      :boolean          default(FALSE), not null
+#  process_trouble        :boolean          default(FALSE), not null
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
 #
@@ -25,5 +27,7 @@ FactoryGirl.define do
     process_test { [true, false].sample }
     process_operation { [true, false].sample }
     process_training { [true, false].sample }
+    process_structure { [true, false].sample }
+    process_trouble { [true, false].sample }
   end
 end

--- a/spec/models/monthly_working_process_spec.rb
+++ b/spec/models/monthly_working_process_spec.rb
@@ -12,6 +12,8 @@
 #  process_operation      :boolean          default(FALSE), not null
 #  process_analysis       :boolean          default(FALSE), not null
 #  process_training       :boolean          default(FALSE), not null
+#  process_structure      :boolean          default(FALSE), not null
+#  process_trouble        :boolean          default(FALSE), not null
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
 #


### PR DESCRIPTION
# 概要
インフラ向けの担当工程を増やす

# 再現・確認手順
月報登録・閲覧・検索時の挙動確認

# 対応Issue（任意）
https://github.com/hr-dash/hr-dash/issues/363

# ToDo

- [x] ラベル付け
- [x] Assigneesで自分を選択
- [x] レビュアーを2人指定する
