### PR TITLE
Hide new tag in smartphone

### DIFF
--- a/app/views/layouts/_announcement_index.html.slim
+++ b/app/views/layouts/_announcement_index.html.slim
@@ -5,7 +5,7 @@
     - date_str = date.strftime('%Y/%m/%d')
     a.list-group-item.announcement-link data-target=(id)
       = "#{date_str}　#{announcement.title}"
-      .pull-right
+      .pull-right.hidden-xs
         - if date > Time.current.to_date.ago(7.days)
           span.label.label-primary New
     .modal.fade id=(id)


### PR DESCRIPTION
# 概要
SP表示時、お知らせのNewタグを非表示にする

# 再現・確認手順
スマホでトップを表示

# 対応Issue（任意）

# ToDo

- [x] ラベル付け
- [x] Assigneesで自分を選択
- [x] レビュアーを2人指定する
