### PR TITLE
ドメインの違うリンクはtarget blank にする

### DIFF
--- a/app/assets/javascripts/main/markdown-parser.js.coffee
+++ b/app/assets/javascripts/main/markdown-parser.js.coffee
@@ -27,3 +27,6 @@ $ ->
     emojify.run(view)
 
   hljs.initHighlightingOnLoad()
+
+  # 他サイトへのリンクはtarget _blank指定
+  $("a[href^='http']:not([href*='" + location.hostname + "'])").attr('target', '_blank')

--- a/app/assets/javascripts/main/markdown-parser.js.coffee
+++ b/app/assets/javascripts/main/markdown-parser.js.coffee
@@ -29,4 +29,5 @@ $ ->
   hljs.initHighlightingOnLoad()
 
   # 他サイトへのリンクはtarget _blank指定
-  $("a[href^='http']:not([href*='" + location.hostname + "'])").attr('target', '_blank')
+  $("a[href^='http']:not([href*='" + location.hostname + "'])")
+    .attr('target', '_blank')


### PR DESCRIPTION
# 概要
主に月報内、コメント内などでリンクを貼られた場合の対策。
自動的に `target="_blank"` が指定されるようにする

# 再現・確認手順
サイト内へのリンクと他サイトへのリンクをつくって、 `target`  指定が切り替わっているか確認

# 対応Issue（任意）
https://github.com/hr-dash/hr-dash/issues/452

# ToDo

- [x] ラベル付け
- [x] Assigneesで自分を選択
- [x] レビュアーを2人指定する
