### PR TITLE
記事機能：ユーザーごとの記事一覧と自分の下書き一覧

### DIFF
--- a/app/assets/stylesheets/main/style.css.scss
+++ b/app/assets/stylesheets/main/style.css.scss
@@ -156,6 +156,15 @@ a[data-toggle="dropdown"], a[data-toggle="collapse"] {
   @extend .monthly-report-index
 }
 
+.article-user {
+  .btn-sm {
+    margin-bottom: 0.5em;
+    a {
+      color: #fff;
+    }
+  }
+}
+
 .article-show {
   .pull-right {
     .glyphicon {

--- a/app/assets/stylesheets/main/style.css.scss
+++ b/app/assets/stylesheets/main/style.css.scss
@@ -165,6 +165,16 @@ a[data-toggle="dropdown"], a[data-toggle="collapse"] {
   }
 }
 
+.article-user-link {
+  margin-top: 0.5em;
+  a {
+    color: #000;
+    &:hover {
+      color: #3a87ad;
+    }
+  }
+}
+
 .article-show {
   .pull-right {
     .glyphicon {

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -9,9 +9,8 @@ class ArticlesController < ApplicationController
   end
 
   def user
-    user = User.find(params[:user_id])
-    @articles = user.articles.includes(article_tags: :tag).shipped.order(shipped_at: :desc).page params[:page]
-    @article_user = @articles.first.user
+    @article_user = User.find(params[:user_id])
+    @articles = @article_user.articles.includes(article_tags: :tag).shipped.order(shipped_at: :desc).page params[:page]
   end
 
   def drafts

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -5,22 +5,22 @@ class ArticlesController < ApplicationController
 
   def index
     references = [:user, { article_tags: :tag }]
-    @articles = Article.includes(references).released.order('shipped_at desc').page params[:page]
+    @articles = Article.includes(references).shipped.order(shipped_at: :desc).page params[:page]
   end
 
   def user
-    @articles = Article.users(params[:user_id]).released.order('shipped_at desc').page params[:page]
+    user = User.find(params[:user_id])
+    @articles = user.articles.includes(article_tags: :tag).shipped.order(shipped_at: :desc).page params[:page]
     @article_user = @articles.first.user
   end
 
   def drafts
-    @articles = Article.users(params[:user_id]).wip.order('created_at desc').page params[:page]
-    forbidden_other_user(@articles.first)
+    @articles = current_user.articles.includes(article_tags: :tag).wip.order(created_at: :desc).page params[:page]
   end
 
   def show
     @article = Article.includes(comments: :user).find(params[:id])
-    forbidden_other_user(@article)
+    raise(Forbidden, 'can not see wip articles of other users') unless @article.browseable?(current_user)
   end
 
   def new
@@ -33,7 +33,12 @@ class ArticlesController < ApplicationController
       assign_relational_params(article)
     end
 
-    save_and_render(:new)
+    if @article.save
+      redirect_to @article
+    else
+      flash_errors(@article)
+      render :new
+    end
   end
 
   def edit; end
@@ -41,11 +46,18 @@ class ArticlesController < ApplicationController
   def update
     @article.assign_attributes(permitted_params)
     assign_relational_params(@article)
-    save_and_render(:edit)
+
+    if @article.save
+      redirect_to @article
+    else
+      flash_errors(@article)
+      render :edit
+    end
   end
 
   def destroy
-    @article = Article.find(params[:id])
+    @article = current_user.articles.find(params[:id])
+
     if @article.destroy
       flash[:notice] = '記事を削除しました'
       redirect_to :articles
@@ -56,19 +68,6 @@ class ArticlesController < ApplicationController
   end
 
   private
-
-  def forbidden_other_user(article)
-    raise(Forbidden, 'can not see wip articles of other users') unless article.browseable?(current_user)
-  end
-
-  def save_and_render(action)
-    if @article.save
-      redirect_to @article
-    else
-      flash_errors(@article)
-      render action
-    end
-  end
 
   def assign_saved_article
     @article = current_user.articles.includes(article_tags: :tag).find(params[:id])
@@ -86,7 +85,7 @@ class ArticlesController < ApplicationController
   end
 
   def assign_relational_params(article)
-    article.shipped! unless params[:wip]
+    article.ship unless params[:wip]
     article.tags = article_tags
   end
 

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -47,6 +47,7 @@ class ArticlesController < ApplicationController
   def destroy
     @article = Article.find(params[:id])
     if @article.destroy
+      flash[:notice] = '記事を削除しました'
       redirect_to :articles
     else
       flash_errors(@article)

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -8,6 +8,16 @@ class ArticlesController < ApplicationController
     @articles = Article.includes(references).released.order('shipped_at desc').page params[:page]
   end
 
+  def user
+    @articles = Article.users(params[:user_id]).released.order('shipped_at desc').page params[:page]
+    @article_user = @articles.first.user
+  end
+
+  def drafts
+    @articles = Article.users(params[:user_id]).wip.order('created_at desc').page params[:page]
+    forbidden_other_user(@articles.first)
+  end
+
   def show
     @article = Article.includes(comments: :user).find(params[:id])
     forbidden_other_user(@article)

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -29,6 +29,8 @@ class Article < ApplicationRecord
   end
 
   scope :released, -> { where.not(shipped_at: nil) }
+  scope :wip, -> { where(shipped_at: nil) }
+  scope :users, ->(id) { includes(article_tags: :tag).where(user: id) }
 
   def shipped!
     self.shipped_at = Time.now

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -28,12 +28,11 @@ class Article < ApplicationRecord
     validates :article_tags, presence: true
   end
 
-  scope :released, -> { where.not(shipped_at: nil) }
+  scope :shipped, -> { where.not(shipped_at: nil) }
   scope :wip, -> { where(shipped_at: nil) }
-  scope :users, ->(id) { includes(article_tags: :tag).where(user: id) }
 
-  def shipped!
-    self.shipped_at = Time.now
+  def ship
+    self.shipped_at ||= Time.current
   end
 
   def shipped?

--- a/app/views/articles/_form.html.slim
+++ b/app/views/articles/_form.html.slim
@@ -16,5 +16,5 @@
     - if article.shipped_at
       = f.button 'Update （記事を更新）', class: 'btn btn-lg btn-success btn-block'
     - else
-      /= f.button 'Save as WIP （下書き保存）', name: :wip, class: 'btn btn-lg btn-info btn-block'
+      = f.button 'Save as WIP （下書き保存）', name: :wip, class: 'btn btn-lg btn-info btn-block'
       = f.button 'Ship（保存して公開）', class: 'btn btn-lg btn-success btn-block'

--- a/app/views/articles/_form.html.slim
+++ b/app/views/articles/_form.html.slim
@@ -3,12 +3,12 @@
     .form-group
       = f.label :title, class: 'control-label col-sm-3'
       .col-sm-9
-        = f.text_field :title, class: 'form-control', placeholder: placeholders[:title]
+        = f.text_field :title, class: 'form-control', placeholder: @placeholders[:title]
     .form-group
       = f.label :article_tags, class: 'control-label col-sm-3'
       .col-sm-9
         = f.hidden_field :article_tags, id: :article_tags_input, class: 'form-control'
-        == render 'layouts/content_tags', tags: article.article_tags.map(&:name), placeholder: placeholders[:tags], content_name: 'article'
+        == render 'layouts/content_tags', tags: article.article_tags.map(&:name), placeholder: @placeholders[:tags], content_name: 'article'
     .form-group
       = f.label :body, class: 'control-label col-sm-3'
       .col-sm-9

--- a/app/views/articles/_form.html.slim
+++ b/app/views/articles/_form.html.slim
@@ -3,12 +3,12 @@
     .form-group
       = f.label :title, class: 'control-label col-sm-3'
       .col-sm-9
-        = f.text_field :title, class: 'form-control', placeholder: @placeholders[:title]
+        = f.text_field :title, class: 'form-control', placeholder: placeholders[:title]
     .form-group
       = f.label :article_tags, class: 'control-label col-sm-3'
       .col-sm-9
         = f.hidden_field :article_tags, id: :article_tags_input, class: 'form-control'
-        == render 'layouts/content_tags', tags: article.article_tags.map(&:name), placeholder: @placeholders[:tags], content_name: 'article'
+        == render 'layouts/document_tags', tags: article.article_tags.map(&:name), placeholder: placeholders[:tags], type: 'article'
     .form-group
       = f.label :body, class: 'control-label col-sm-3'
       .col-sm-9

--- a/app/views/articles/drafts.html.slim
+++ b/app/views/articles/drafts.html.slim
@@ -1,0 +1,10 @@
+- provide :page_title, '下書き中の記事一覧'
+.article-user
+  .btn.btn-success.btn-sm
+    = link_to '公開済みの記事一覧へ', user_articles_path(current_user)
+
+  .page-content
+    #article-index
+      .list-group.article-index
+        == render partial: 'layouts/article_index', collection: @articles,as: 'article'
+    = paginate @articles

--- a/app/views/articles/drafts.html.slim
+++ b/app/views/articles/drafts.html.slim
@@ -4,7 +4,7 @@
     = link_to '公開済みの記事一覧へ', user_articles_path(current_user)
 
   .page-content
-    #article-index
+    #article_index
       .list-group.article-index
         == render partial: 'layouts/article_index', collection: @articles,as: 'article'
     = paginate @articles

--- a/app/views/articles/drafts.html.slim
+++ b/app/views/articles/drafts.html.slim
@@ -6,5 +6,8 @@
   .page-content
     #article_index
       .list-group.article-index
-        == render partial: 'layouts/article_index', collection: @articles,as: 'article'
+        - if @articles.present?
+          == render partial: 'layouts/article_index', collection: @articles,as: 'article'
+        - else
+          p 下書き中の記事はありません
     = paginate @articles

--- a/app/views/articles/show.html.slim
+++ b/app/views/articles/show.html.slim
@@ -19,6 +19,8 @@
              a.glyphicon.glyphicon-remove data-toggle="modal" data-target="#article-confirm"
     .panel-body
       = render 'layouts/markdown_view', content: @article.body
+  .pull-right.article-user-link
+    = link_to "#{@article.user.name}さんの記事一覧へ", user_articles_path(@article.user.id)
 .modal.fade#article-confirm
   .modal-dialog
     .modal-content

--- a/app/views/articles/user.html.slim
+++ b/app/views/articles/user.html.slim
@@ -6,5 +6,8 @@
   .page-content
     #article_index
       .list-group.article-index
-        == render partial: 'layouts/article_index', collection: @articles, as: 'article'
+        - if @articles.present?
+          == render partial: 'layouts/article_index', collection: @articles, as: 'article'
+        - else
+          p 公開中の記事はありません
     = paginate @articles

--- a/app/views/articles/user.html.slim
+++ b/app/views/articles/user.html.slim
@@ -1,0 +1,10 @@
+- provide :page_title, (link_to "#{@article_user.name}さんの記事一覧", user_profile_path(@article_user.user_profile), class: 'text-profile-link')
+.article-user
+  - if @article_user == current_user
+    .btn.btn-info.btn-sm
+      = link_to '下書き中の記事一覧へ', drafts_articles_path(current_user)
+  .page-content
+    #article_index
+      .list-group.article-index
+        == render partial: 'layouts/article_index', collection: @articles, as: 'article'
+    = paginate @articles

--- a/app/views/layouts/_document_tags.html.erb
+++ b/app/views/layouts/_document_tags.html.erb
@@ -1,13 +1,13 @@
-<div id="<%= content_name %>_tags" class="tag-list"></div>
+<div id="<%= type %>_tags" class="tag-list"></div>
 
 <script>
 $(function(){
   var refresh_tags_input = function(self) {
-    var input = $('#<%= content_name %>_tags_input');
+    var input = $('#<%= type %>_tags_input');
     (typeof(input) == undefined) ? null : input.val(self.getTags());
   }
 
-  var tagger = $('#<%= content_name %>_tags').tags({
+  var tagger = $('#<%= type %>_tags').tags({
       tagData: <%= tags.to_json.html_safe %>,
       suggestions: <%= Tag.fixed.pluck(:name).to_json.html_safe %>,
       suggestOnClick: true,
@@ -23,6 +23,6 @@ $(function(){
   });
   refresh_tags_input(tagger);
 
-  $('#<%= content_name %>_tags > input').focusout(function() { this.value = ''; });
+  $('#<%= type %>_tags > input').focusout(function() { this.value = ''; });
 });
 </script>

--- a/app/views/layouts/_header_main_menus.html.slim
+++ b/app/views/layouts/_header_main_menus.html.slim
@@ -22,6 +22,8 @@ li.dropdown
       = link_to "トップ", articles_path
     li
       = link_to "新規投稿", new_article_path
+    li
+      = link_to "自分の記事一覧", user_articles_path(current_user)
 li.dropdown.hidden-xs
   a.lead.bg-primary.dropdown-toggle data-toggle="dropdown" aria-expanded="false"
     span.glyphicon.glyphicon-th-list aria-hidden="true"

--- a/app/views/monthly_reports/_form.html.slim
+++ b/app/views/monthly_reports/_form.html.slim
@@ -22,7 +22,7 @@
       = f.label :monthly_report_tags, class: 'control-label col-sm-3'
       .col-sm-9
         = f.hidden_field :monthly_report_tags, id: :monthly_report_tags_input, class: 'form-control'
-        == render 'layouts/content_tags', tags: monthly_report.monthly_report_tags.map(&:name), placeholder: placeholders[:tags], content_name: 'monthly_report'
+        == render 'layouts/document_tags', tags: monthly_report.monthly_report_tags.map(&:name), placeholder: placeholders[:tags], type: 'monthly_report'
     .form-group
       = f.label :monthly_working_process, class: 'control-label col-sm-3'
       .col-sm-9.btn-group data-toggle="buttons"

--- a/app/views/monthly_reports/index.html.slim
+++ b/app/views/monthly_reports/index.html.slim
@@ -21,7 +21,7 @@
           = f.label :tags_name_in, '使用した技術', class: 'control-label col-xs-2'
           .col-xs-10
             = f.hidden_field :tags_name_in, id: :monthly_report_tags_input, class: 'form-control'
-            == render 'layouts/content_tags', tags: @q.tags_name_in, placeholder: placeholders[:tags], content_name: 'monthly_report'
+            == render 'layouts/document_tags', tags: @q.tags_name_in, placeholder: placeholders[:tags], type: 'monthly_report'
         .form-group
           = f.label :monthly_working_process, '担当した工程', class: 'control-label col-xs-2'
           .col-xs-10.btn-group.btn-group-sm data-toggle="buttons"

--- a/config/locales/activerecord.ja.yml
+++ b/config/locales/activerecord.ja.yml
@@ -14,6 +14,7 @@ ja:
       tag: タグ
       user: ユーザー
       user_profile: プロフィール
+      article: 記事
     attributes:
       announcement:
         title: タイトル
@@ -74,6 +75,10 @@ ja:
         self_introduction: 自己紹介
         blood_type: 血液型
         birthday: 生年月日
+      article:
+        title: タイトル
+        article_tags: タグ
+        body: 本文
   activemodel:
     <<: activerecord
   enums:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,7 +34,12 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :articles
+  resources :articles, constraints: Constraints::PageCount do
+    collection do
+      get 'users/:user_id', action: :user, as: :user, user_id: /\d{,6}/
+      get 'users/:user_id/drafts', action: :drafts, as: :drafts, user_id: /\d{,6}/
+    end
+  end
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".
 

--- a/spec/features/articles_spec.rb
+++ b/spec/features/articles_spec.rb
@@ -14,6 +14,34 @@ describe ArticlesController, type: :feature do
     end
   end
 
+  describe '#user GET /articles/users/:user_id' do
+    let!(:today) { create(:article, :with_tags, user: user, shipped_at: Date.today) }
+    let!(:yesterday) { create(:article, :with_tags, user: user, shipped_at: Date.yesterday) }
+    let(:first_report) { find('#article_index').first('a') }
+    let(:title) { find('.page-header') }
+    let(:btn) { find('.btn.btn-info').first('a') }
+
+    before { visit user_articles_path(user) }
+
+    it { expect(first_report[:href]).to eq article_path(today) }
+    it { expect(btn).to have_content '下書き中の記事一覧へ' }
+    it { expect(title).to have_content "#{user.name}さんの記事一覧" }
+  end
+
+  describe '#drafts GET /articles/users/:user_id/drafts' do
+    let!(:today) { create(:article, :with_tags, user: user) }
+    let!(:yesterday) { create(:article, :with_tags, user: user) }
+    let(:first_report) { find('#article_index').first('a') }
+    let(:title) { find('.page-header') }
+    let(:btn) { find('.article-user').first('div') }
+
+    before { visit drafts_articles_path(user) }
+
+    it { expect(first_report[:href]).to eq article_path(yesterday) }
+    it { expect(btn).to have_content '公開済みの記事一覧へ' }
+    it { expect(title).to have_content '下書き中の記事一覧' }
+  end
+
   describe '#create POST /articles', js: true do
     before { visit new_article_path }
 
@@ -70,6 +98,18 @@ describe ArticlesController, type: :feature do
     it { expect(title).to have_content 'すごいH本を読んでみた' }
     it { expect(tags).to have_content 'Haskell' }
     it { expect(body).to have_content 'Haskellすごーい、たのしー！' }
+  end
+
+  describe '#destroy DELETE /article/:id', js: true do
+    let!(:article) { create(:shipped_article, user: user) }
+    before do
+      visit article_path(article)
+      find('a.glyphicon-remove').click
+      click_on 'はい'
+    end
+
+    it { expect(page).to have_content '記事を削除しました' }
+    it { expect(current_path).to eq '/articles' }
   end
 
   describe '#show GET /artices/:id' do

--- a/spec/features/articles_spec.rb
+++ b/spec/features/articles_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+describe ArticlesController, type: :feature do
+  let(:user) { create(:user) }
+  before { login user }
+
+  describe '#index GET /articles' do
+    describe 'sort by shipped_at desc' do
+      let!(:today) { create(:article, :with_tags, shipped_at: Date.today) }
+      let!(:yesterday) { create(:article, :with_tags, shipped_at: Date.yesterday) }
+      let(:first_report) { find('#article_index').first('a') }
+
+      before { visit articles_path }
+      it { expect(first_report[:href]).to eq article_path(today) }
+    end
+  end
+
+  describe '#create POST /articles', js: true do
+    before { visit new_article_path }
+
+    context 'valid' do
+      let(:status) { find('.article-status').text }
+
+      context 'registered as wip' do
+        before do
+          fill_in 'タイトル', with: 'すごいH本を読んでみた'
+          find('#article_tags_input').set('Haskell')
+          click_button 'Save as WIP （下書き保存）'
+        end
+
+        it { expect(page).not_to have_content '本文を入力してください' }
+        it { expect(status).to eq '下書き' }
+      end
+
+      context 'registered as shipped' do
+        before do
+          fill_in 'タイトル', with: 'すごいH本を読んでみた'
+          find('#article_tags_input').set('Haskell')
+          fill_in '本文', with: 'Haskellすごーい、たのしー！'
+          click_button 'Ship（保存して公開）'
+        end
+
+        it { expect(page).not_to have_content '本文を入力してください' }
+        it { expect(status).to eq '公開済' }
+      end
+    end
+
+    context 'in valid' do
+      before { click_button 'Ship（保存して公開）' }
+
+      it { expect(page).to have_content 'タイトルを入力してください' }
+      it { expect(page).to have_content '本文を入力してください' }
+      it { expect(page).to have_content 'タグを入力してください' }
+    end
+  end
+
+  describe '#update PATCH /article/:id', js: true do
+    let!(:article) { create(:shipped_article, user: user) }
+    let(:title) { find('.page-header') }
+    let(:tags) { find('.tags') }
+    let(:body) { find('.article-show') }
+
+    before do
+      visit edit_article_path(article)
+      fill_in 'タイトル', with: 'すごいH本を読んでみた'
+      find('#article_tags_input').set('Haskell')
+      fill_in '本文', with: 'Haskellすごーい、たのしー！'
+      click_button 'Update （記事を更新）'
+    end
+
+    it { expect(title).to have_content 'すごいH本を読んでみた' }
+    it { expect(tags).to have_content 'Haskell' }
+    it { expect(body).to have_content 'Haskellすごーい、たのしー！' }
+  end
+
+  describe '#show GET /artices/:id' do
+    before { visit article_path(article) }
+
+    context 'show own article' do
+      subject { find('.article-status').text }
+
+      context 'is shipped' do
+        let!(:article) { create(:shipped_article, user: user) }
+
+        it { is_expected.to eq '公開済' }
+      end
+
+      context 'is wip' do
+        let!(:article) { create(:article, :wip, user: user) }
+
+        it { is_expected.to eq '下書き' }
+      end
+    end
+
+    context 'show other user article' do
+      let(:other_user) { create(:user) }
+
+      context 'is shipped' do
+        let!(:article) { create(:shipped_article, user: other_user) }
+
+        it { expect(page).not_to have_selector '.article-status' }
+      end
+
+      context 'is wip' do
+        let!(:article) { create(:article, :wip, user: other_user) }
+        let(:body) { find('.error-body') }
+
+        it { expect(body).to have_content '403' }
+      end
+    end
+  end
+end


### PR DESCRIPTION
# 概要
* サイドバーから自分の記事一覧に遷移できるようにした。
* ユーザーの記事一覧を閲覧時に現在のユーザーと記事のユーザーが同じ場合は下書き一覧へのリンクを表示する。
* 他のユーザーの記事一覧への導線
* テストの追加
# 再現・確認手順

# 対応Issue（任意）
#435 
# ToDo

- [x] ラベル付け
- [x] Assigneesで自分を選択
- [x] レビュアーを2人指定する
