### PR TITLE
開発環境のWEBrickをPumaに変更

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -92,6 +92,7 @@ group :development do
   gem 'rails_real_favicon'
   gem 'web-console', '~> 2.0'
   gem 'listen'
+  gem 'puma'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -307,6 +307,7 @@ GEM
       pry (~> 0.10)
     pry-rails (0.3.5)
       pry (>= 0.9.10)
+    puma (3.8.2)
     rack (2.0.1)
     rack-contrib (1.2.0)
       rack (>= 0.9.1)
@@ -538,6 +539,7 @@ DEPENDENCIES
   pry
   pry-byebug
   pry-rails
+  puma
   rack_session_access
   rails (~> 5.0.2)
   rails-controller-testing
@@ -564,4 +566,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   1.14.3
+   1.14.6


### PR DESCRIPTION
# 概要
開発環境のWEBrickをPumaに変更
少し起動が早い..？

# 再現・確認手順

```sh
$ bundle exec rails s
=> Booting Puma
=> Rails 5.0.2 application starting in development on http://localhost:3000
=> Run `rails server -h` for more startup options
Puma starting in single mode...
* Version 3.8.2 (ruby 2.3.1-p112), codename: Sassy Salamander
* Min threads: 5, max threads: 5
* Environment: development
* Listening on tcp://localhost:3000
Use Ctrl-C to stop
```

# 対応Issue（任意）
なし

# ToDo

- [x] ラベル付け
- [x] Assigneesで自分を選択
- [ ] レビュアーを2人指定する
