### PR TITLE
WIP: RSpecの実行速度を早める

### DIFF
--- a/spec/features/admin/action_log_spec.rb
+++ b/spec/features/admin/action_log_spec.rb
@@ -17,12 +17,14 @@ describe 'Admin::HelpText', type: :feature do
 
   describe '#index' do
     before { visit admin_active_admin_action_logs_path }
-    it { expect(page_title).to have_content('Active Admin Action Logs') }
-    it { expect(page).to have_content(user.name) }
-    it { expect(page).to have_content('Group') }
-    it { expect(page).to have_content(new_group.name) }
-    it { expect(page).not_to have_content('作成する') }
-    it { expect(page).not_to have_css('.delete_link') }
+    it 'should open the index page' do
+      expect(page_title).to have_content('Active Admin Action Logs')
+      expect(page).to have_content(user.name)
+      expect(page).to have_content('Group')
+      expect(page).to have_content(new_group.name)
+      expect(page).not_to have_content('作成する')
+      expect(page).not_to have_css('.delete_link')
+    end
   end
 
   describe '#show' do
@@ -33,10 +35,12 @@ describe 'Admin::HelpText', type: :feature do
       find("#active_admin_action_log_#{log.id}").find('.view_link').click
     end
 
-    it { expect(page_title).to have_content("##{log.id}") }
-    it { expect(page).to have_content(user.name) }
-    it { expect(page).to have_content(log.resource_type) }
-    it { expect(page).to have_content(log.path) }
-    it { expect(page).to have_content(log.action) }
+    it 'should open the show page' do
+      expect(page_title).to have_content("##{log.id}")
+      expect(page).to have_content(user.name)
+      expect(page).to have_content(log.resource_type)
+      expect(page).to have_content(log.path)
+      expect(page).to have_content(log.action)
+    end
   end
 end

--- a/spec/features/admin/group_spec.rb
+++ b/spec/features/admin/group_spec.rb
@@ -8,16 +8,20 @@ describe 'Admin::Group', type: :feature do
 
   describe '#index' do
     before { visit admin_groups_path }
-    it { expect(page_title).to have_content('グループ') }
-    it { expect(page).to have_content(group.name) }
-    it { expect(page).to have_content('作成する') }
-    it { expect(page).not_to have_css('.delete_link') }
+    it 'should open the index page' do
+      expect(page_title).to have_content('グループ')
+      expect(page).to have_content(group.name)
+      expect(page).to have_content('作成する')
+      expect(page).not_to have_css('.delete_link')
+    end
   end
 
   describe '#show' do
     before { visit admin_group_path(group) }
-    it { expect(page_title).to have_content(group.name) }
-    it { expect(page).to have_content(user.name) }
+    it 'should open the show page' do
+      expect(page_title).to have_content(group.name)
+      expect(page).to have_content(user.name)
+    end
   end
 
   describe '#create' do
@@ -30,8 +34,10 @@ describe 'Admin::Group', type: :feature do
       click_on 'グループを作成'
     end
 
-    it { expect(page_title).to have_content(new_group.name) }
-    it { expect(page).to have_content(new_group.description) }
+    it 'should create the new group' do
+      expect(page_title).to have_content(new_group.name)
+      expect(page).to have_content(new_group.description)
+    end
   end
 
   describe '#update' do
@@ -42,10 +48,12 @@ describe 'Admin::Group', type: :feature do
       click_on 'グループを更新'
     end
 
-    it { expect(page_title).to have_content(group.name) }
-    it { expect(current_path).to eq admin_group_path(group) }
-    it { expect(page).to have_content(new_description) }
-    it { expect(group.reload.description).to eq new_description }
+    it 'should update the group' do
+      expect(page_title).to have_content(group.name)
+      expect(current_path).to eq admin_group_path(group)
+      expect(page).to have_content(new_description)
+      expect(group.reload.description).to eq new_description
+    end
   end
 
   describe '#update_group_assign', js: true do
@@ -58,10 +66,12 @@ describe 'Admin::Group', type: :feature do
       sleep 0.4
     end
 
-    it { expect(page_title).to have_content(group.name) }
-    it { expect(current_path).to eq admin_group_path(group) }
-    it { expect(group.users).to include(another_user) }
-    it { expect(group.users).not_to include(user) }
+    it 'should assign user to group' do
+      expect(page_title).to have_content(group.name)
+      expect(current_path).to eq admin_group_path(group)
+      expect(group.users).to include(another_user)
+      expect(group.users).not_to include(user)
+    end
   end
 
   describe '#import_csv' do
@@ -70,8 +80,10 @@ describe 'Admin::Group', type: :feature do
     context 'no input csv file' do
       before { find('input[type=submit]').click }
 
-      it { expect(current_path).to eq do_import_admin_groups_path }
-      it { expect(page).to have_content('インポートするファイルを選択してください') }
+      it 'should open the import groups page' do
+        expect(current_path).to eq do_import_admin_groups_path
+        expect(page).to have_content('インポートするファイルを選択してください')
+      end
     end
 
     context 'input valid csv file' do
@@ -84,16 +96,18 @@ describe 'Admin::Group', type: :feature do
         find('input[type=submit]').click
       end
 
-      it { expect(current_path).to eq import_admin_groups_path }
-      it { expect(page).to have_content('2つのグループのインポートに成功しました') }
-      it { expect(yamada).to be_present }
-      it { expect(yamada.name).to eq '山田' }
-      it { expect(yamada.email).to eq 'yamada.group@example.com' }
-      it { expect(yamada.description).to eq '山田グループ' }
-      it { expect(suzuki).to be_present }
-      it { expect(suzuki.name).to eq '鈴木' }
-      it { expect(suzuki.email).to eq 'suzuki.group@example.com' }
-      it { expect(suzuki.description).to eq '鈴木グループ' }
+      it 'should imoprt group by csv' do
+        expect(current_path).to eq import_admin_groups_path
+        expect(page).to have_content('2つのグループのインポートに成功しました')
+        expect(yamada).to be_present
+        expect(yamada.name).to eq '山田'
+        expect(yamada.email).to eq 'yamada.group@example.com'
+        expect(yamada.description).to eq '山田グループ'
+        expect(suzuki).to be_present
+        expect(suzuki.name).to eq '鈴木'
+        expect(suzuki.email).to eq 'suzuki.group@example.com'
+        expect(suzuki.description).to eq '鈴木グループ'
+      end
     end
   end
 end

--- a/spec/features/admin/help_text_spec.rb
+++ b/spec/features/admin/help_text_spec.rb
@@ -6,18 +6,22 @@ describe 'Admin::HelpText', type: :feature do
 
   describe '#index' do
     before { visit admin_help_texts_path }
-    it { expect(page_title).to have_content('ヘルプテキスト') }
-    it { expect(page).to have_content(help_text.category) }
-    it { expect(page).not_to have_content('作成する') }
-    it { expect(page).not_to have_css('.delete_link') }
+    it 'should open the index page' do
+      expect(page_title).to have_content('ヘルプテキスト')
+      expect(page).to have_content(help_text.category)
+      expect(page).not_to have_content('作成する')
+      expect(page).not_to have_css('.delete_link')
+    end
   end
 
   describe '#show' do
     before { visit admin_help_text_path(help_text) }
-    it { expect(page_title).to have_content("##{help_text.id}") }
-    it { expect(page).to have_content(help_text.category) }
-    it { expect(page).to have_content(help_text.target) }
-    it { expect(page).to have_content(help_text.body) }
+    it 'should open the show page' do
+      expect(page_title).to have_content("##{help_text.id}")
+      expect(page).to have_content(help_text.category)
+      expect(page).to have_content(help_text.target)
+      expect(page).to have_content(help_text.body)
+    end
   end
 
   describe '#update' do
@@ -28,9 +32,11 @@ describe 'Admin::HelpText', type: :feature do
       click_on 'ヘルプテキストを更新'
     end
 
-    it { expect(page_title).to have_content("##{help_text.id}") }
-    it { expect(current_path).to eq admin_help_text_path(help_text) }
-    it { expect(page).to have_content(new_body) }
-    it { expect(help_text.reload.body).to eq new_body }
+    it 'should update the help text' do
+      expect(page_title).to have_content("##{help_text.id}")
+      expect(current_path).to eq admin_help_text_path(help_text)
+      expect(page).to have_content(new_body)
+      expect(help_text.reload.body).to eq new_body
+    end
   end
 end

--- a/spec/features/admin/inquiry_spec.rb
+++ b/spec/features/admin/inquiry_spec.rb
@@ -6,17 +6,21 @@ describe 'Admin::Inquiry', type: :feature do
 
   describe '#index' do
     before { visit admin_inquiries_path }
-    it { expect(page_title).to have_content('問い合わせ') }
-    it { expect(page).to have_content(inquiry.referer) }
-    it { expect(page).to have_content('編集') }
-    it { expect(page).not_to have_css('.delete_link') }
+    it 'should open the index page' do
+      expect(page_title).to have_content('問い合わせ')
+      expect(page).to have_content(inquiry.referer)
+      expect(page).to have_content('編集')
+      expect(page).not_to have_css('.delete_link')
+    end
   end
 
   describe '#show' do
     before { visit admin_inquiry_path(inquiry) }
-    it { expect(page_title).to have_content("問い合わせ ##{inquiry.id}") }
-    it { expect(page).to have_content(inquiry.user.name) }
-    it { expect(page).to have_content(inquiry.body) }
+    it 'should open the show page' do
+      expect(page_title).to have_content("問い合わせ ##{inquiry.id}")
+      expect(page).to have_content(inquiry.user.name)
+      expect(page).to have_content(inquiry.body)
+    end
   end
 
   describe '#update' do
@@ -27,9 +31,11 @@ describe 'Admin::Inquiry', type: :feature do
       click_on '問い合わせを更新'
     end
 
-    it { expect(page_title).to have_content("問い合わせ ##{inquiry.id}") }
-    it { expect(current_path).to eq admin_inquiry_path(inquiry) }
-    it { expect(page).to have_content(new_admin_memo) }
-    it { expect(inquiry.reload.admin_memo).to eq new_admin_memo }
+    it 'should update the inquiry' do
+      expect(page_title).to have_content("問い合わせ ##{inquiry.id}")
+      expect(current_path).to eq admin_inquiry_path(inquiry)
+      expect(page).to have_content(new_admin_memo)
+      expect(inquiry.reload.admin_memo).to eq new_admin_memo
+    end
   end
 end

--- a/spec/features/admin/monthly_report_comment_spec.rb
+++ b/spec/features/admin/monthly_report_comment_spec.rb
@@ -8,10 +8,12 @@ describe 'Admin::MonthlyReportComment', type: :feature do
 
   describe '#index' do
     before { visit admin_monthly_report_comments_path }
-    it { expect(page_title).to have_content('月報コメント') }
-    it { expect(page).to have_content(user.name) }
-    it { expect(page).to have_content(comment.comment) }
-    it { expect(page).to have_css('.delete_link') }
+    it 'should open the index page' do
+      expect(page_title).to have_content('月報コメント')
+      expect(page).to have_content(user.name)
+      expect(page).to have_content(comment.comment)
+      expect(page).to have_css('.delete_link')
+    end
   end
 
   describe '#show' do
@@ -27,9 +29,11 @@ describe 'Admin::MonthlyReportComment', type: :feature do
       click_on '月報コメントを更新'
     end
 
-    it { expect(page).to have_content(new_comment) }
-    it { expect(current_path).to eq admin_monthly_report_comment_path(comment) }
-    it { expect(comment.reload.comment).to eq new_comment }
+    it 'should update the monthly report comment' do
+      expect(page).to have_content(new_comment)
+      expect(current_path).to eq admin_monthly_report_comment_path(comment)
+      expect(comment.reload.comment).to eq new_comment
+    end
   end
 
   describe '#destroy', js: true do
@@ -40,8 +44,10 @@ describe 'Admin::MonthlyReportComment', type: :feature do
       end
     end
 
-    it { expect(current_path).to eq admin_monthly_report_comments_path }
-    it { expect(page).not_to have_content(comment.comment) }
-    it { expect { comment.reload }.to raise_error(ActiveRecord::RecordNotFound) }
+    it 'should destroy the monthly report comment' do
+      expect(current_path).to eq admin_monthly_report_comments_path
+      expect(page).not_to have_content(comment.comment)
+      expect { comment.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    end
   end
 end

--- a/spec/features/admin/monthly_report_spec.rb
+++ b/spec/features/admin/monthly_report_spec.rb
@@ -7,10 +7,12 @@ describe 'Admin::MonthlyReport', type: :feature do
 
   describe '#index' do
     before { visit admin_monthly_reports_path }
-    it { expect(page_title).to have_content('月報') }
-    it { expect(page).to have_content(user.name) }
-    it { expect(page).to have_content(report.shipped_at) }
-    it { expect(page).not_to have_css('.delete_link') }
+    it 'should open the index page' do
+      expect(page_title).to have_content('月報')
+      expect(page).to have_content(user.name)
+      expect(page).to have_content(report.shipped_at)
+      expect(page).not_to have_css('.delete_link')
+    end
   end
 
   describe '#show' do
@@ -26,8 +28,10 @@ describe 'Admin::MonthlyReport', type: :feature do
       click_on '月報を更新'
     end
 
-    it { expect(page).to have_content(new_summary) }
-    it { expect(current_path).to eq admin_monthly_report_path(report) }
-    it { expect(report.reload.project_summary).to eq new_summary }
+    it 'should update the monthly report' do
+      expect(page).to have_content(new_summary)
+      expect(current_path).to eq admin_monthly_report_path(report)
+      expect(report.reload.project_summary).to eq new_summary
+    end
   end
 end

--- a/spec/features/admin/monthly_report_tag_spec.rb
+++ b/spec/features/admin/monthly_report_tag_spec.rb
@@ -9,9 +9,11 @@ describe 'Admin::MonthlyReportTag', type: :feature do
 
   describe '#index' do
     before { visit admin_monthly_report_tags_path }
-    it { expect(page_title).to have_content('月報タグ') }
-    it { expect(page).to have_content(tag.name) }
-    it { expect(page).to have_css('.delete_link') }
+    it 'should open the index page' do
+      expect(page_title).to have_content('月報タグ')
+      expect(page).to have_content(tag.name)
+      expect(page).to have_css('.delete_link')
+    end
   end
 
   describe '#show' do
@@ -27,9 +29,11 @@ describe 'Admin::MonthlyReportTag', type: :feature do
       click_on '月報タグを更新'
     end
 
-    it { expect(page).to have_content(new_tag.name) }
-    it { expect(current_path).to eq admin_monthly_report_tag_path(report_tag) }
-    it { expect(report_tag.reload.tag).to eq new_tag }
+    it 'should update the monthly report tag' do
+      expect(page).to have_content(new_tag.name)
+      expect(current_path).to eq admin_monthly_report_tag_path(report_tag)
+      expect(report_tag.reload.tag).to eq new_tag
+    end
   end
 
   describe '#destroy', js: true do
@@ -40,8 +44,10 @@ describe 'Admin::MonthlyReportTag', type: :feature do
       end
     end
 
-    it { expect(current_path).to eq admin_monthly_report_tags_path }
-    it { expect(page).not_to have_content(tag.name) }
-    it { expect { report_tag.reload }.to raise_error(ActiveRecord::RecordNotFound) }
+    it 'should destroy the monthly report tag' do
+      expect(current_path).to eq admin_monthly_report_tags_path
+      expect(page).not_to have_content(tag.name)
+      expect { report_tag.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    end
   end
 end

--- a/spec/features/admin/monthly_working_process_spec.rb
+++ b/spec/features/admin/monthly_working_process_spec.rb
@@ -8,11 +8,13 @@ describe 'Admin::MonthlyWorkingProcess', type: :feature do
 
   describe '#index' do
     before { visit admin_monthly_working_processes_path }
-    it { expect(page_title).to have_content('月別担当業務') }
-    it { expect(page).to have_content(user.name) }
-    it { expect(page).not_to have_content('作成する') }
-    it { expect(page).to have_content('閲覧') }
-    it { expect(page).not_to have_css('.delete_link') }
+    it 'should open the index page' do
+      expect(page_title).to have_content('月別担当業務')
+      expect(page).to have_content(user.name)
+      expect(page).not_to have_content('作成する')
+      expect(page).to have_content('閲覧')
+      expect(page).not_to have_css('.delete_link')
+    end
   end
 
   describe '#show' do

--- a/spec/features/admin/tag_spec.rb
+++ b/spec/features/admin/tag_spec.rb
@@ -6,16 +6,20 @@ describe 'Admin::Tag', type: :feature do
 
   describe '#index' do
     before { visit admin_tags_path }
-    it { expect(page_title).to have_content('タグ') }
-    it { expect(page).to have_content(tag.name) }
-    it { expect(page).to have_content('作成する') }
-    it { expect(page).not_to have_css('.delete_link') }
+    it 'should open the index page' do
+      expect(page_title).to have_content('タグ')
+      expect(page).to have_content(tag.name)
+      expect(page).to have_content('作成する')
+      expect(page).not_to have_css('.delete_link')
+    end
   end
 
   describe '#show' do
     before { visit admin_tag_path(tag) }
-    it { expect(page_title).to have_content(tag.name) }
-    it { expect(page).to have_content(tag.name) }
+    it 'should open the show page' do
+      expect(page_title).to have_content(tag.name)
+      expect(page).to have_content(tag.name)
+    end
   end
 
   describe '#create' do
@@ -27,8 +31,10 @@ describe 'Admin::Tag', type: :feature do
       click_on 'タグを作成'
     end
 
-    it { expect(page_title).to have_content(new_tag.name) }
-    it { expect(page).to have_content('fixed') }
+    it 'should create the new tag' do
+      expect(page_title).to have_content(new_tag.name)
+      expect(page).to have_content('fixed')
+    end
   end
 
   describe '#update' do
@@ -39,10 +45,12 @@ describe 'Admin::Tag', type: :feature do
       click_on 'タグを更新'
     end
 
-    it { expect(page_title).to have_content(new_name) }
-    it { expect(current_path).to eq admin_tag_path(tag) }
-    it { expect(page).to have_content(new_name) }
-    it { expect(tag.reload.name).to eq new_name }
+    it 'should update the tag' do
+      expect(page_title).to have_content(new_name)
+      expect(current_path).to eq admin_tag_path(tag)
+      expect(page).to have_content(new_name)
+      expect(tag.reload.name).to eq new_name
+    end
   end
 
   describe 'batch_action', js: true do
@@ -57,15 +65,19 @@ describe 'Admin::Tag', type: :feature do
     context 'fixedにする' do
       before { click_on '選択した行をfixedにする' }
 
-      it { expect(page).to have_content('1個のタグをfixedにしました') }
-      it { expect(tag.reload).to be_fixed }
+      it 'should update tag status to fixed' do
+        expect(page).to have_content('1個のタグをfixedにしました')
+        expect(tag.reload).to be_fixed
+      end
     end
 
     context 'ignoredにする' do
       before { click_on '選択した行をignoredにする' }
 
-      it { expect(page).to have_content('1個のタグをignoredにしました') }
-      it { expect(tag.reload).to be_ignored }
+      it 'should update tag status to ignored' do
+        expect(page).to have_content('1個のタグをignoredにしました')
+        expect(tag.reload).to be_ignored
+      end
     end
   end
 end

--- a/spec/features/admin/user_profile_spec.rb
+++ b/spec/features/admin/user_profile_spec.rb
@@ -7,16 +7,20 @@ describe 'Admin::UserProfile', type: :feature do
 
   describe '#index' do
     before { visit admin_user_profiles_path }
-    it { expect(page_title).to have_content('プロフィール') }
-    it { expect(page).to have_content(user.name) }
-    it { expect(page).not_to have_content('作成する') }
-    it { expect(page).not_to have_css('.delete_link') }
+    it 'should open the index page' do
+      expect(page_title).to have_content('プロフィール')
+      expect(page).to have_content(user.name)
+      expect(page).not_to have_content('作成する')
+      expect(page).not_to have_css('.delete_link')
+    end
   end
 
   describe '#show' do
     before { visit admin_user_profile_path(profile) }
-    it { expect(page_title).to have_content("##{profile.id}") }
-    it { expect(page).to have_content(profile.blood_type_i18n) }
+    it 'should open the show page' do
+      expect(page_title).to have_content("##{profile.id}")
+      expect(page).to have_content(profile.blood_type_i18n)
+    end
   end
 
   describe '#update' do
@@ -27,9 +31,11 @@ describe 'Admin::UserProfile', type: :feature do
       click_on 'プロフィールを更新'
     end
 
-    it { expect(page_title).to have_content("##{profile.id}") }
-    it { expect(current_path).to eq admin_user_profile_path(profile) }
-    it { expect(page).to have_content(new_introduction) }
-    it { expect(profile.reload.self_introduction).to eq new_introduction }
+    it 'should update introduction of user profile' do
+      expect(page_title).to have_content("##{profile.id}")
+      expect(current_path).to eq admin_user_profile_path(profile)
+      expect(page).to have_content(new_introduction)
+      expect(profile.reload.self_introduction).to eq new_introduction
+    end
   end
 end

--- a/spec/features/admin/user_role_spec.rb
+++ b/spec/features/admin/user_role_spec.rb
@@ -7,10 +7,12 @@ describe 'Admin::UserRole', type: :feature do
 
   describe '#index' do
     before { visit admin_user_roles_path }
-    it { expect(page_title).to have_content('ロール') }
-    it { expect(page).to have_content(user.name) }
-    it { expect(page).to have_content('作成する') }
-    it { expect(page).to have_css('.delete_link') }
+    it 'should open the index page' do
+      expect(page_title).to have_content('ロール')
+      expect(page).to have_content(user.name)
+      expect(page).to have_content('作成する')
+      expect(page).to have_css('.delete_link')
+    end
   end
 
   describe '#show' do
@@ -27,8 +29,10 @@ describe 'Admin::UserRole', type: :feature do
       click_on 'ロールを作成'
     end
 
-    it { expect(page).to have_content(new_user.name) }
-    it { expect(current_path).to eq admin_user_role_path(new_user.role) }
+    it 'should create the new user role' do
+      expect(page).to have_content(new_user.name)
+      expect(current_path).to eq admin_user_role_path(new_user.role)
+    end
   end
 
   describe '#destroy', js: true do
@@ -39,9 +43,11 @@ describe 'Admin::UserRole', type: :feature do
       end
     end
 
-    it { expect(current_path).to eq admin_user_roles_path }
-    it { expect(page).not_to have_content(user.name) }
-    it { expect { role.reload }.to raise_error(ActiveRecord::RecordNotFound) }
+    it 'should destroy the user role' do
+      expect(current_path).to eq admin_user_roles_path
+      expect(page).not_to have_content(user.name)
+      expect { role.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    end
   end
 
   describe 'cannot access if operator' do

--- a/spec/features/admin/user_spec.rb
+++ b/spec/features/admin/user_spec.rb
@@ -6,15 +6,19 @@ describe 'Admin::User', type: :feature do
 
   describe '#index' do
     before { visit admin_users_path }
-    it { expect(page_title).to have_content('ユーザ') }
-    it { expect(page).to have_content(user.name) }
-    it { expect(page).not_to have_css('.delete_link') }
+    it 'should open the index page' do
+      expect(page_title).to have_content('ユーザ')
+      expect(page).to have_content(user.name)
+      expect(page).not_to have_css('.delete_link')
+    end
   end
 
   describe '#show' do
     before { visit admin_user_path(user) }
-    it { expect(page_title).to have_content(user.name) }
-    it { expect(page).to have_content('PW変更') }
+    it 'should open the show page' do
+      expect(page_title).to have_content(user.name)
+      expect(page).to have_content('PW変更')
+    end
   end
 
   describe '#create' do
@@ -31,13 +35,15 @@ describe 'Admin::User', type: :feature do
       click_on 'ユーザーを作成'
     end
 
-    it { expect(current_path).to eq admin_user_path(created_user) }
-    it { expect(user_params.name).to eq created_user.name }
-    it { expect(user_params.gender).to eq created_user.gender }
-    it { expect(user_params.employee_code).to eq created_user.employee_code }
-    it { expect(user_params.email).to eq created_user.email }
-    it { expect(user_params.entry_date).to eq created_user.entry_date }
-    it { expect(user_params.beginner_flg).to eq created_user.beginner_flg }
+    it 'should create the new user' do
+      expect(current_path).to eq admin_user_path(created_user)
+      expect(user_params.name).to eq created_user.name
+      expect(user_params.gender).to eq created_user.gender
+      expect(user_params.employee_code).to eq created_user.employee_code
+      expect(user_params.email).to eq created_user.email
+      expect(user_params.entry_date).to eq created_user.entry_date
+      expect(user_params.beginner_flg).to eq created_user.beginner_flg
+    end
   end
 
   describe '#update' do
@@ -48,9 +54,11 @@ describe 'Admin::User', type: :feature do
       click_on 'ユーザーを更新'
     end
 
-    it { expect(page_title).to have_content(new_name) }
-    it { expect(user.reload.name).to eq new_name }
-    it { expect(current_path).to eq admin_user_path(user) }
+    it 'should update the user' do
+      expect(page_title).to have_content(new_name)
+      expect(user.reload.name).to eq new_name
+      expect(current_path).to eq admin_user_path(user)
+    end
   end
 
   describe '#import_csv' do
@@ -59,8 +67,10 @@ describe 'Admin::User', type: :feature do
     context 'no input csv file' do
       before { click_on 'インポートする' }
 
-      it { expect(current_path).to eq input_csv_admin_users_path }
-      it { expect(page).to have_content('CSVファイルを指定してください') }
+      it 'should import csv' do
+        expect(current_path).to eq input_csv_admin_users_path
+        expect(page).to have_content('CSVファイルを指定してください')
+      end
     end
 
     context 'input valid csv file' do
@@ -73,18 +83,20 @@ describe 'Admin::User', type: :feature do
         click_on 'インポートする'
       end
 
-      it { expect(current_path).to eq admin_users_path }
-      it { expect(page).to have_content('2名のユーザーがインポートされました') }
-      it { expect(yamada).to be_present }
-      it { expect(yamada.email).to eq 'yamada.taro@example.com' }
-      it { expect(yamada.gender).to eq 'male' }
-      it { expect(yamada.beginner_flg).to eq true }
-      it { expect(yamada.user_profile).to be_present }
-      it { expect(suzuki).to be_present }
-      it { expect(suzuki.email).to eq 'suzuki.hanako@example.com' }
-      it { expect(suzuki.gender).to eq 'female' }
-      it { expect(suzuki.beginner_flg).to eq false }
-      it { expect(suzuki.user_profile).to be_present }
+      it 'should import user from csv' do
+        expect(current_path).to eq admin_users_path
+        expect(page).to have_content('2名のユーザーがインポートされました')
+        expect(yamada).to be_present
+        expect(yamada.email).to eq 'yamada.taro@example.com'
+        expect(yamada.gender).to eq 'male'
+        expect(yamada.beginner_flg).to eq true
+        expect(yamada.user_profile).to be_present
+        expect(suzuki).to be_present
+        expect(suzuki.email).to eq 'suzuki.hanako@example.com'
+        expect(suzuki.gender).to eq 'female'
+        expect(suzuki.beginner_flg).to eq false
+        expect(suzuki.user_profile).to be_present
+      end
     end
   end
 
@@ -98,9 +110,11 @@ describe 'Admin::User', type: :feature do
       click_on '更新する'
     end
 
-    it { expect(current_path).to eq admin_users_path }
-    it { expect(page_title).to have_content('ユーザー') }
-    it { expect(other_user.reload.valid_password?(new_password)).to be true }
+    it 'should update the password' do
+      expect(current_path).to eq admin_users_path
+      expect(page_title).to have_content('ユーザー')
+      expect(other_user.reload.valid_password?(new_password)).to be true
+    end
   end
 
   describe '#delete_monthly_report', js: true do
@@ -116,11 +130,13 @@ describe 'Admin::User', type: :feature do
         accept_confirm { click_link('月報を削除する') }
       end
 
-      it { expect(page).to have_content('月報を削除する') }
-      it { expect(target_user.monthly_reports).to be_blank }
-      it { expect(tags).to be_blank }
-      it { expect(comments).to be_blank }
-      it { expect(working_process).to be_blank }
+      it 'should delete the monthly report' do
+        expect(page).to have_content('月報を削除する')
+        expect(target_user.monthly_reports).to be_blank
+        expect(tags).to be_blank
+        expect(comments).to be_blank
+        expect(working_process).to be_blank
+      end
     end
 
     context 'not retired user reports' do

--- a/spec/features/monthly_report_spec.rb
+++ b/spec/features/monthly_report_spec.rb
@@ -26,9 +26,11 @@ describe MonthlyReportsController, type: :feature do
           click_link '>'
         end
 
-        it { expect(current_path).to eq monthly_reports_path }
-        it { expect(find('div.tag > span').text).to eq tag.name }
-        it { expect(query).to include "q[tags_name_in][]=#{tag.name}" }
+        it 'can search by tag name' do
+          expect(current_path).to eq monthly_reports_path
+          expect(find('div.tag > span').text).to eq tag.name
+          expect(query).to include "q[tags_name_in][]=#{tag.name}"
+        end
       end
     end
 
@@ -47,9 +49,11 @@ describe MonthlyReportsController, type: :feature do
         click_button '検索'
       end
 
-      it { expect(current_path).to eq monthly_reports_path }
-      it { expect(query).to include "q[target_month_eq]=#{report1.target_month}" }
-      it { expect(query).not_to include "q[target_month_eq]=#{report2.target_month}" }
+      it 'can search by month' do
+        expect(current_path).to eq monthly_reports_path
+        expect(query).to include "q[target_month_eq]=#{report1.target_month}"
+        expect(query).not_to include "q[target_month_eq]=#{report2.target_month}"
+      end
     end
   end
 
@@ -60,7 +64,9 @@ describe MonthlyReportsController, type: :feature do
     let!(:next) { create(:monthly_report, :wip, user: user, target_month: report.target_month.next_month) }
     before { visit monthly_report_path(report) }
 
-    it { expect(page).to have_link('先月') }
-    it { expect(page).not_to have_link('来月') }
+    it 'exists link for paging' do
+      expect(page).to have_link('先月')
+      expect(page).not_to have_link('来月')
+    end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -89,4 +89,8 @@ RSpec.configure do |config|
   config.include ::Rails::Controller::Testing::TestProcess, type: :request
   config.include ::Rails::Controller::Testing::TemplateAssertions, type: :request
   config.include ::Rails::Controller::Testing::Integration, type: :request
+
+  config.define_derived_metadata do |metadata|
+    metadata[:aggregate_failures] = true unless metadata.key?(:aggregate_failures)
+  end
 end


### PR DESCRIPTION
# 概要
- `it` ブロックをまとめる方針でテストの実行速度を上げる
- 本来は `it` 内で1件でもfailすると他のテストは実行されないが、設定追加してすべて実行するようにした
- `spec/features/monthly_report_spec.rb`, `spec/feature/admin` 配下だけ適用

# 再現・確認手順

```
$ bundle exec rspec -fd --color --profile
```

## 結果

### before

```
Top 10 slowest examples (15.39 seconds, 22.7% of total time):
  Admin::Group #update_group_assign should text "菅原 響"
    7.18 seconds ./spec/features/admin/group_spec.rb:61
  Admin::HelpText #index should text "Active Admin Action Logs"
    2.13 seconds ./spec/features/admin/action_log_spec.rb:20
  Admin::Group #update_group_assign should include #<User id: 17722, name: "坂本 真央", employee_code: "336702799596", encrypted_email: "9qR4vCTiLIXXcSRLAZ1...nil, created_at: "2017-05-18 17:05:59", updated_at: "2017-05-18 17:05:59", gender: "gender_unknown">
    0.84481 seconds ./spec/features/admin/group_spec.rb:63
  Admin::Group #update_group_assign should not include #<User id: 17724, name: "高田 美緒", employee_code: "354428363399", encrypted_email: "xo2cg3tQJr3Q5cnNrCI...ted_at: nil, created_at: "2017-05-18 17:06:00", updated_at: "2017-05-18 17:06:00", gender: "female">
    0.83478 seconds ./spec/features/admin/group_spec.rb:64
  Admin::Group #update_group_assign should eq "/admin/groups/18295"
    0.82767 seconds ./spec/features/admin/group_spec.rb:62
  Admin::User #delete_monthly_report retired user reports should be blank
    0.75611 seconds ./spec/features/admin/user_spec.rb:120
  Admin::MonthlyReportTag #destroy should not text "dicta12"
    0.74793 seconds ./spec/features/admin/monthly_report_tag_spec.rb:44
  Admin::MonthlyReportComment #destroy should eq "/admin/monthly_report_comments"
    0.71078 seconds ./spec/features/admin/monthly_report_comment_spec.rb:43
  Admin::Tag batch_action ignoredにする should be ignored
    0.68704 seconds ./spec/features/admin/tag_spec.rb:68
  Admin::User #delete_monthly_report retired user reports should be blank
    0.66573 seconds ./spec/features/admin/user_spec.rb:122

Top 10 slowest example groups:
  Admin::Group
    0.58615 seconds average (16.41 seconds / 28 examples) ./spec/features/admin/group_spec.rb:2
  Admin::HelpText
    0.56305 seconds average (6.19 seconds / 11 examples) ./spec/features/admin/action_log_spec.rb:2
  Admin::MonthlyReportTag
    0.40061 seconds average (4.01 seconds / 10 examples) ./spec/features/admin/monthly_report_tag_spec.rb:2
  Admin::MonthlyReportComment
    0.38194 seconds average (4.2 seconds / 11 examples) ./spec/features/admin/monthly_report_comment_spec.rb:2
  Admin::User
    0.35471 seconds average (13.83 seconds / 39 examples) ./spec/features/admin/user_spec.rb:2
  Admin::UserRole
    0.35095 seconds average (3.86 seconds / 11 examples) ./spec/features/admin/user_role_spec.rb:2
  Admin::Tag
    0.33863 seconds average (5.42 seconds / 16 examples) ./spec/features/admin/tag_spec.rb:2
  Admin::MonthlyWorkingProcess
    0.27694 seconds average (1.66 seconds / 6 examples) ./spec/features/admin/monthly_working_process_spec.rb:2
  Admin::MonthlyReport
    0.27201 seconds average (2.18 seconds / 8 examples) ./spec/features/admin/monthly_report_spec.rb:2
  Admin::Inquiry
    0.26823 seconds average (2.95 seconds / 11 examples) ./spec/features/admin/inquiry_spec.rb:2

Finished in 1 minute 7.78 seconds (files took 12.29 seconds to load)
183 examples, 0 failures
```

### after

```
Top 10 slowest examples (14.68 seconds, 51.8% of total time):
  Admin::Group #update_group_assign should assign user to group
    7.77 seconds ./spec/features/admin/group_spec.rb:69
  Admin::HelpText #index should open the index page
    2.29 seconds ./spec/features/admin/action_log_spec.rb:20
  Admin::User #delete_monthly_report retired user reports should delete the monthly report
    0.6623 seconds ./spec/features/admin/user_spec.rb:133
  Admin::Tag batch_action ignoredにする should update tag status to ignored
    0.65907 seconds ./spec/features/admin/tag_spec.rb:77
  Admin::MonthlyReportComment #destroy should destroy the monthly report comment
    0.63681 seconds ./spec/features/admin/monthly_report_comment_spec.rb:47
  Admin::Tag batch_action fixedにする should update tag status to fixed
    0.6013 seconds ./spec/features/admin/tag_spec.rb:68
  Admin::UserRole #destroy should destroy the user role
    0.59306 seconds ./spec/features/admin/user_role_spec.rb:46
  Admin::MonthlyReportTag #destroy should destroy the monthly report tag
    0.58682 seconds ./spec/features/admin/monthly_report_tag_spec.rb:47
  Admin::HelpText #show should open the show page
    0.44439 seconds ./spec/features/admin/action_log_spec.rb:38
  Admin::User #delete_monthly_report not retired user reports should not text "月報を削除する"
    0.43795 seconds ./spec/features/admin/user_spec.rb:148

Top 10 slowest example groups:
  Admin::Group
    1.37 seconds average (9.6 seconds / 7 examples) ./spec/features/admin/group_spec.rb:2
  Admin::HelpText
    1.37 seconds average (2.74 seconds / 2 examples) ./spec/features/admin/action_log_spec.rb:2
  Admin::MonthlyReportComment
    0.39284 seconds average (1.57 seconds / 4 examples) ./spec/features/admin/monthly_report_comment_spec.rb:2
  Admin::Tag
    0.3665 seconds average (2.2 seconds / 6 examples) ./spec/features/admin/tag_spec.rb:2
  Admin::MonthlyReportTag
    0.34622 seconds average (1.38 seconds / 4 examples) ./spec/features/admin/monthly_report_tag_spec.rb:2
  Admin::UserRole
    0.34376 seconds average (1.72 seconds / 5 examples) ./spec/features/admin/user_role_spec.rb:2
  Admin::User
    0.3403 seconds average (3.4 seconds / 10 examples) ./spec/features/admin/user_spec.rb:2
  Admin::Inquiry
    0.30208 seconds average (0.90624 seconds / 3 examples) ./spec/features/admin/inquiry_spec.rb:2
  Admin::MonthlyWorkingProcess
    0.26504 seconds average (0.53008 seconds / 2 examples) ./spec/features/admin/monthly_working_process_spec.rb:2
  Admin::MonthlyReport
    0.26182 seconds average (0.78546 seconds / 3 examples) ./spec/features/admin/monthly_report_spec.rb:2

Finished in 28.37 seconds (files took 12.43 seconds to load)
62 examples, 0 failures
```

# 対応Issue（任意）
なし

# ToDo

- [x] ラベル付け
- [x] Assigneesで自分を選択
- [ ] レビュアーを2人指定する
