### PR TITLE
bundlerのバージョンをアップグレード

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -368,7 +368,7 @@ GEM
     rblineprof (0.3.7)
       debugger-ruby_core_source (~> 1.3)
     rchardet (1.6.1)
-    rdoc (4.2.0)
+    rdoc (4.3.0)
     reek (4.5.1)
       codeclimate-engine-rb (~> 0.4.0)
       parser (~> 2.3.1, >= 2.3.1.2)
@@ -566,4 +566,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   1.14.6
+   1.16.0


### PR DESCRIPTION
# 概要
CircleCI上での `bundle install` が失敗していたので確認すると、`Gemfile.lock`とCircleCIのbundlerのバージョンが違うことから`rdoc`のインストールに失敗しているようでした。

CircleCIのbundlerが1.16.0なので、Gemfile.lockのbundlerも1.16.0に合わせてもよいのでは？

# 再現・確認手順
```
gem install bundler -v 1.16.0
bundle install --path vendor/bundle
```
`rdoc`インストールで落ちるので、`bundle update rdoc`

# 対応Issue（任意）

# ToDo

- [x] ラベル付け
- [x] Assigneesで自分を選択
- [ ] レビュアーを2人指定する
