### PR TITLE
Add sideci.yml

### DIFF
--- a/sideci.yml
+++ b/sideci.yml
@@ -1,0 +1,4 @@
+linter:
+  rubocop:
+    options:
+      config: '.rubocop.yml'


### PR DESCRIPTION
Unify the results of rubocop

# 概要

- ローカルとリモートでRuboCopの結果が異なるのでどうにかしたい
- これでたぶん `.rubocop.yml` 見るようになる

# 再現・確認手順

- マージしてSideCIの結果を待つ
    - ローカルの結果と同じになること